### PR TITLE
Add a migration for structures and blinds

### DIFF
--- a/migrations/20230824124339_add_structures_and_blinds.sql
+++ b/migrations/20230824124339_add_structures_and_blinds.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE structures (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR NOT NULL
+);
+
+CREATE TABLE blinds (
+  id SERIAL PRIMARY KEY,
+  small INTEGER NOT NULL,
+  big INTEGER NOT NULL,
+  ante INTEGER NOT NULL,
+  time INTEGER NOT NULL,
+  index SMALLINT NOT NULL,
+  structure_id INTEGER,
+  CONSTRAINT blinds_structure_id_fkey FOREIGN KEY (structure_id) REFERENCES structures(id)
+);
+
+ALTER TABLE events ADD COLUMN structure_id INTEGER;
+ALTER TABLE events ADD CONSTRAINT events_structure_id_fkey FOREIGN KEY (structure_id) REFERENCES structures(id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE events DROP COLUMN structure_id;
+DROP TABLE blinds;
+DROP TABLE structures;
+-- +goose StatementEnd


### PR DESCRIPTION
Adds a new migration to add two new tables:
- `blinds`
- `structures`
Also adds a new column `structure_id` to the `events` table that is a reference to the structures table.

Closes #194 