### PR TITLE
feat(events): move rebuys from participants to events

### DIFF
--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -20,6 +20,7 @@ type Event struct {
 	StartDate   time.Time `json:"startDate"`
 	State       uint8     `json:"state"`
 	StructureID uint64    `json:"structureId"`
+	Rebuys      uint8     `json:"rebuys"`
 }
 
 type CreateEventRequest struct {

--- a/internal/models/participant.go
+++ b/internal/models/participant.go
@@ -12,7 +12,6 @@ type Participant struct {
 	EventID      uint64     `json:"eventId"`
 	Placement    uint32     `json:"placement"`
 	SignedOutAt  *time.Time `json:"signedOutAt"`
-	Rebuys       uint8      `json:"rebuys"`
 }
 
 type CreateParticipantRequest struct {
@@ -25,7 +24,6 @@ type UpdateParticipantRequest struct {
 	EventID      uint64    `json:"eventId" binding:"required"`
 	SignIn       bool
 	SignOut      bool
-	Rebuy        bool
 }
 
 type DeleteParticipantRequest struct {
@@ -40,5 +38,4 @@ type ListParticipantsResult struct {
 	LastName     string     `json:"lastName"`
 	SignedOutAt  *time.Time `json:"signedOutAt"`
 	Placement    uint32     `json:"placement"`
-	Rebuys       uint8      `json:"rebuys"`
 }

--- a/internal/server/events_handler.go
+++ b/internal/server/events_handler.go
@@ -73,5 +73,21 @@ func (s *apiServer) EndEvent(ctx *gin.Context) {
 	}
 
 	ctx.String(http.StatusNoContent, "")
+}
 
+func (s *apiServer) NewRebuy(ctx *gin.Context) {
+	eventId, err := strconv.ParseUint(ctx.Param("eventId"), 10, 32)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, e.InvalidRequest("Invalid event ID specified in request"))
+		return
+	}
+
+	svc := services.NewEventService(s.db)
+	err = svc.NewRebuy(eventId)
+	if err != nil {
+		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
+		return
+	}
+
+	ctx.String(http.StatusOK, "")
 }

--- a/internal/server/participants_handler.go
+++ b/internal/server/participants_handler.go
@@ -83,25 +83,6 @@ func (s *apiServer) SignInParticipant(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, participant)
 }
 
-func (s *apiServer) RebuyParticipant(ctx *gin.Context) {
-	var req models.UpdateParticipantRequest
-	err := ctx.ShouldBindJSON(&req)
-	if err != nil {
-		ctx.JSON(http.StatusBadRequest, e.InvalidRequest(err.Error()))
-		return
-	}
-	req.Rebuy = true
-
-	svc := services.NewParticipantsService(s.db)
-	participant, err := svc.UpdateParticipant(&req)
-	if err != nil {
-		ctx.JSON(err.(e.APIErrorResponse).Code, err)
-		return
-	}
-
-	ctx.JSON(http.StatusOK, participant)
-}
-
 func (s *apiServer) DeleteParticipant(ctx *gin.Context) {
 	var req models.DeleteParticipantRequest
 	err := ctx.ShouldBindJSON(&req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,6 +83,7 @@ func (s *apiServer) SetupRoutes() {
 		eventsRoute.POST("", s.CreateEvent)
 		eventsRoute.GET(":eventId", s.GetEvent)
 		eventsRoute.POST(":eventId/end", s.EndEvent)
+		eventsRoute.POST(":eventId/rebuy", s.NewRebuy)
 	}
 
 	membershipRoutes := s.r.Group("/memberships", middleware.UseAuthentication)
@@ -99,7 +100,6 @@ func (s *apiServer) SetupRoutes() {
 		participantRoute.POST("", s.CreateParticipant)
 		participantRoute.POST("sign-out", s.SignOutParticipant)
 		participantRoute.POST("sign-in", s.SignInParticipant)
-		participantRoute.POST("rebuy", s.RebuyParticipant)
 		participantRoute.DELETE("", s.DeleteParticipant)
 	}
 

--- a/internal/services/events_service_test.go
+++ b/internal/services/events_service_test.go
@@ -73,6 +73,7 @@ func TestEventService(t *testing.T) {
 		assert.Equal(t, semester1.ID.String(), event.SemesterID.String(), "Event.SemesterID")
 		assert.Equal(t, date, event.StartDate, "Event.StartDate")
 		assert.Equal(t, structure.ID, event.StructureID)
+		assert.EqualValues(t, 0, event.Rebuys)
 	})
 
 	t.Run("ListEvents", func(t *testing.T) {
@@ -110,6 +111,7 @@ func TestEventService(t *testing.T) {
 			StartDate:   event1Date,
 			State:       models.EventStateStarted,
 			StructureID: structure.ID,
+			Rebuys:      0,
 		}
 		event2 := models.Event{
 			Name:        "Event 2",
@@ -119,6 +121,7 @@ func TestEventService(t *testing.T) {
 			StartDate:   event2Date,
 			State:       models.EventStateEnded,
 			StructureID: structure.ID,
+			Rebuys:      0,
 		}
 		event3 := models.Event{
 			Name:        "Event 3",
@@ -128,6 +131,7 @@ func TestEventService(t *testing.T) {
 			StartDate:   event3Date,
 			State:       models.EventStateStarted,
 			StructureID: structure.ID,
+			Rebuys:      0,
 		}
 
 		res = db.Create(&event1)
@@ -181,6 +185,7 @@ func TestEventService(t *testing.T) {
 			StartDate:   event1Date,
 			State:       models.EventStateStarted,
 			StructureID: structure.ID,
+			Rebuys:      0,
 		}
 
 		res = db.Create(&event1)
@@ -224,6 +229,7 @@ func TestEventService(t *testing.T) {
 				StartDate:   event1Date,
 				State:       models.EventStateStarted,
 				StructureID: structure.ID,
+				Rebuys:      0,
 			}
 
 			res = db.Create(&event1)
@@ -248,14 +254,14 @@ func TestEventService(t *testing.T) {
 			assert.NoError(t, err, "Event creation")
 
 			now := time.Now().UTC()
-			_, err = testhelpers.CreateParticipant(db, set.Memberships[0].ID, event.ID, 0, &now, 2)
+			_, err = testhelpers.CreateParticipant(db, set.Memberships[0].ID, event.ID, 0, &now)
 			assert.NoError(t, err, "Adding first entry")
 
 			next := now.Add(time.Minute * 30)
-			_, err = testhelpers.CreateParticipant(db, set.Memberships[1].ID, event.ID, 0, &next, 0)
+			_, err = testhelpers.CreateParticipant(db, set.Memberships[1].ID, event.ID, 0, &next)
 			assert.NoError(t, err, "Adding second entry")
 
-			entry3, err := testhelpers.CreateParticipant(db, set.Memberships[2].ID, event.ID, 0, nil, 4)
+			entry3, err := testhelpers.CreateParticipant(db, set.Memberships[2].ID, event.ID, 0, nil)
 			assert.NoError(t, err, "Adding third entry")
 
 			err = eventService.EndEvent(event.ID)
@@ -277,15 +283,15 @@ func TestEventService(t *testing.T) {
 			assert.NoError(t, err, "Event creation")
 
 			now := time.Now().UTC()
-			entry1, err := testhelpers.CreateParticipant(db, set.Memberships[0].ID, event.ID, 0, &now, 2)
+			entry1, err := testhelpers.CreateParticipant(db, set.Memberships[0].ID, event.ID, 0, &now)
 			assert.NoError(t, err, "Adding first entry")
 
 			next := now.Add(time.Minute * 30)
-			entry2, err := testhelpers.CreateParticipant(db, set.Memberships[1].ID, event.ID, 0, &next, 0)
+			entry2, err := testhelpers.CreateParticipant(db, set.Memberships[1].ID, event.ID, 0, &next)
 			assert.NoError(t, err, "Adding second entry")
 
 			last := next.Add(time.Minute * 30)
-			entry3, err := testhelpers.CreateParticipant(db, set.Memberships[2].ID, event.ID, 0, &last, 4)
+			entry3, err := testhelpers.CreateParticipant(db, set.Memberships[2].ID, event.ID, 0, &last)
 			assert.NoError(t, err, "Adding third entry")
 
 			err = eventService.EndEvent(event.ID)
@@ -338,5 +344,57 @@ func TestEventService(t *testing.T) {
 			assert.EqualValues(t, 2, ranking2.Points, "Ranking 2 points")
 			assert.EqualValues(t, 2, ranking3.Points, "Ranking 3 points")
 		})
+	})
+	t.Run("NewRebuy", func(t *testing.T) {
+		t.Cleanup(wipeDB)
+
+		semester1 := models.Semester{
+			Name:                  "Spring 2022",
+			Meta:                  "",
+			StartDate:             time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:               time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
+			StartingBudget:        105.57,
+			CurrentBudget:         105.57,
+			MembershipFee:         10,
+			MembershipDiscountFee: 5,
+			RebuyFee:              2,
+		}
+		res := db.Create(&semester1)
+		assert.NoError(t, res.Error, "GetEvent (create semester)")
+
+		structure := models.Structure{
+			Name: "Main Event Structure",
+		}
+		res = db.Create(&structure)
+		assert.NoError(t, res.Error, "ListEvents (create structure)")
+
+		event1Date := time.Date(2022, 1, 1, 7, 0, 0, 0, time.Local)
+
+		event1 := models.Event{
+			Name:        "Event 1",
+			Format:      "NLHE",
+			Notes:       "#1",
+			SemesterID:  semester1.ID,
+			StartDate:   event1Date,
+			State:       models.EventStateStarted,
+			StructureID: structure.ID,
+			Rebuys:      0,
+		}
+
+		res = db.Create(&event1)
+		assert.NoError(t, res.Error, "GetEvent (create event)")
+
+		err = eventService.NewRebuy(event1.ID)
+		assert.NoError(t, err, "EventService.NewRebuy()")
+
+		updatedEvent := models.Event{ID: event1.ID}
+		res = db.First(&updatedEvent)
+		assert.NoError(t, res.Error, "Retrieve updated event")
+		assert.EqualValues(t, 1, updatedEvent.Rebuys, "Rebuy count not updated")
+
+		updatedSemester := models.Semester{ID: semester1.ID}
+		res = db.First(&updatedSemester)
+		assert.NoError(t, res.Error, "Retrieve updated semester")
+		assert.InDelta(t, updatedSemester.CurrentBudget, semester1.CurrentBudget+float64(semester1.RebuyFee), 0.001)
 	})
 }

--- a/internal/testhelpers/helpers.go
+++ b/internal/testhelpers/helpers.go
@@ -65,6 +65,7 @@ func CreateEvent(db *gorm.DB, name string, semesterId uuid.UUID, startDate time.
 		StartDate:   startDate,
 		State:       models.EventStateStarted,
 		StructureID: structure.ID,
+		Rebuys:      0,
 	}
 
 	res = db.Create(&event)
@@ -91,13 +92,12 @@ func CreateMembership(db *gorm.DB, userId uint64, semesterId uuid.UUID, paid boo
 	return &membership, nil
 }
 
-func CreateParticipant(db *gorm.DB, membershipId uuid.UUID, eventId uint64, placement uint32, signedOutAt *time.Time, rebuys uint8) (*models.Participant, error) {
+func CreateParticipant(db *gorm.DB, membershipId uuid.UUID, eventId uint64, placement uint32, signedOutAt *time.Time) (*models.Participant, error) {
 	entry := models.Participant{
 		MembershipID: membershipId,
 		EventID:      eventId,
 		Placement:    placement,
 		SignedOutAt:  signedOutAt,
-		Rebuys:       rebuys,
 	}
 
 	res := db.Create(&entry)

--- a/migrations/20230904172933_move_rebuy_to_events.sql
+++ b/migrations/20230904172933_move_rebuy_to_events.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE participants DROP COLUMN rebuys;
+ALTER TABLE events ADD COLUMN rebuys SMALLINT NOT NULL DEFAULT '0'::SMALLINT
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE events DROP COLUMN rebuys;
+ALTER TABLE participants ADD COLUMN rebuys SMALLINT NOT NULL DEFAULT '0'::SMALLINT
+-- +goose StatementEnd


### PR DESCRIPTION
Moves the `rebuys` field from `participants` to `events` so it is now a "global" count of the rebuys across an event instead of a count of an individual person's rebuys.

Closes #202

**BREAKING CHANGE**: Removes the rebuy route on participants, and adds a new route on events as a replacement