### PR TITLE
fix(events): use ListEventsResponse type to capture event entry count

### DIFF
--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -40,4 +40,5 @@ type ListEventsResponse struct {
 	SemesterID string    `json:"semesterId" gorm:"type:uuid"`
 	StartDate  time.Time `json:"startDate"`
 	State      uint8     `json:"state"`
+	Count      int32     `json:"count"`
 }

--- a/internal/services/events_service.go
+++ b/internal/services/events_service.go
@@ -62,8 +62,8 @@ func (es *eventService) GetEvent(eventId uint64) (*models.Event, error) {
 	return &event, nil
 }
 
-func (es *eventService) ListEvents(semesterId string) ([]models.Event, error) {
-	var events []models.Event
+func (es *eventService) ListEvents(semesterId string) ([]models.ListEventsResponse, error) {
+	var events []models.ListEventsResponse
 
 	query := es.db.
 		Table("events").


### PR DESCRIPTION
Fixes the event entry count not showing on the event list due to an incorrect type being used to scan the DB results.

Fixes #203
