### PR TITLE
feat(events): add a points multiplier to events

### DIFF
--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -12,24 +12,26 @@ const (
 )
 
 type Event struct {
-	ID          uint64    `json:"id"`
-	Name        string    `json:"name"`
-	Format      string    `json:"format"`
-	Notes       string    `json:"notes"`
-	SemesterID  uuid.UUID `json:"semesterId" gorm:"type:uuid"`
-	StartDate   time.Time `json:"startDate"`
-	State       uint8     `json:"state"`
-	StructureID uint64    `json:"structureId"`
-	Rebuys      uint8     `json:"rebuys"`
+	ID               uint64    `json:"id"`
+	Name             string    `json:"name"`
+	Format           string    `json:"format"`
+	Notes            string    `json:"notes"`
+	SemesterID       uuid.UUID `json:"semesterId" gorm:"type:uuid"`
+	StartDate        time.Time `json:"startDate"`
+	State            uint8     `json:"state"`
+	StructureID      uint64    `json:"structureId"`
+	Rebuys           uint8     `json:"rebuys"`
+	PointsMultiplier float32   `json:"pointsMultiplier"`
 }
 
 type CreateEventRequest struct {
-	Name        string    `json:"name" binding:"required"`
-	Format      string    `json:"format" binding:"required"`
-	Notes       string    `json:"notes"`
-	SemesterID  string    `json:"semesterId" binding:"required"`
-	StartDate   time.Time `json:"startDate" binding:"required"`
-	StructureID uint64    `json:"structureId" binding:"required"`
+	Name             string    `json:"name" binding:"required"`
+	Format           string    `json:"format" binding:"required"`
+	Notes            string    `json:"notes"`
+	SemesterID       string    `json:"semesterId" binding:"required"`
+	StartDate        time.Time `json:"startDate" binding:"required"`
+	StructureID      uint64    `json:"structureId" binding:"required"`
+	PointsMultiplier float32   `json:"pointsMulitplier" binding:"required"`
 }
 
 type ListEventsResponse struct {

--- a/internal/services/events_service.go
+++ b/internal/services/events_service.go
@@ -26,14 +26,15 @@ func (es *eventService) CreateEvent(req *models.CreateEventRequest) (*models.Eve
 	}
 
 	event := models.Event{
-		Name:        req.Name,
-		Format:      req.Format,
-		Notes:       req.Notes,
-		SemesterID:  semesterId,
-		StartDate:   req.StartDate,
-		State:       models.EventStateStarted,
-		StructureID: req.StructureID,
-		Rebuys:      0,
+		Name:             req.Name,
+		Format:           req.Format,
+		Notes:            req.Notes,
+		SemesterID:       semesterId,
+		StartDate:        req.StartDate,
+		State:            models.EventStateStarted,
+		StructureID:      req.StructureID,
+		Rebuys:           0,
+		PointsMultiplier: req.PointsMultiplier,
 	}
 
 	res := es.db.Create(&event)
@@ -142,7 +143,7 @@ func (es *eventService) EndEvent(eventId uint64) error {
 	rankingService := NewRankingService(tx)
 	eventSize := len(entries)
 	for i, entry := range entries {
-		points := CalculatePoints(eventSize, i+1)
+		points := CalculatePoints(eventSize, i+1, event.PointsMultiplier)
 
 		err := rankingService.UpdateRanking(entry.MembershipID, points)
 		if err != nil {

--- a/internal/services/events_service_test.go
+++ b/internal/services/events_service_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEventService(t *testing.T) {
+func TestEventsService(t *testing.T) {
 	t.Setenv("ENVIRONMENT", "TEST")
 
 	db, err := database.OpenTestConnection()
@@ -58,12 +58,13 @@ func TestEventService(t *testing.T) {
 		date := time.Now()
 
 		req := &models.CreateEventRequest{
-			Name:        "test",
-			Format:      "NLHE",
-			Notes:       "test event",
-			SemesterID:  semester1.ID.String(),
-			StartDate:   date,
-			StructureID: structure.ID,
+			Name:             "test",
+			Format:           "NLHE",
+			Notes:            "test event",
+			SemesterID:       semester1.ID.String(),
+			StartDate:        date,
+			StructureID:      structure.ID,
+			PointsMultiplier: 2.3,
 		}
 
 		event, err := eventService.CreateEvent(req)
@@ -72,8 +73,9 @@ func TestEventService(t *testing.T) {
 		assert.Equal(t, req.Format, event.Format, "Event.Format")
 		assert.Equal(t, semester1.ID.String(), event.SemesterID.String(), "Event.SemesterID")
 		assert.Equal(t, date, event.StartDate, "Event.StartDate")
-		assert.Equal(t, structure.ID, event.StructureID)
-		assert.EqualValues(t, 0, event.Rebuys)
+		assert.Equal(t, structure.ID, event.StructureID, "Event.StructureID")
+		assert.EqualValues(t, 0, event.Rebuys, "Event.Rebuys")
+		assert.InDelta(t, 2.3, event.PointsMultiplier, 0.01, "Event.PointsMultiplier")
 	})
 
 	t.Run("ListEvents", func(t *testing.T) {
@@ -178,14 +180,15 @@ func TestEventService(t *testing.T) {
 		event1Date := time.Date(2022, 1, 1, 7, 0, 0, 0, time.Local)
 
 		event1 := models.Event{
-			Name:        "Event 1",
-			Format:      "NLHE",
-			Notes:       "#1",
-			SemesterID:  semester1.ID,
-			StartDate:   event1Date,
-			State:       models.EventStateStarted,
-			StructureID: structure.ID,
-			Rebuys:      0,
+			Name:             "Event 1",
+			Format:           "NLHE",
+			Notes:            "#1",
+			SemesterID:       semester1.ID,
+			StartDate:        event1Date,
+			State:            models.EventStateStarted,
+			StructureID:      structure.ID,
+			Rebuys:           0,
+			PointsMultiplier: 2.3,
 		}
 
 		res = db.Create(&event1)
@@ -222,14 +225,15 @@ func TestEventService(t *testing.T) {
 			event1Date := time.Date(2022, 1, 1, 7, 0, 0, 0, time.UTC)
 
 			event1 := models.Event{
-				Name:        "Event 1",
-				Format:      "NLHE",
-				Notes:       "#1",
-				SemesterID:  semester1.ID,
-				StartDate:   event1Date,
-				State:       models.EventStateStarted,
-				StructureID: structure.ID,
-				Rebuys:      0,
+				Name:             "Event 1",
+				Format:           "NLHE",
+				Notes:            "#1",
+				SemesterID:       semester1.ID,
+				StartDate:        event1Date,
+				State:            models.EventStateStarted,
+				StructureID:      structure.ID,
+				Rebuys:           0,
+				PointsMultiplier: 2.3,
 			}
 
 			res = db.Create(&event1)
@@ -371,14 +375,15 @@ func TestEventService(t *testing.T) {
 		event1Date := time.Date(2022, 1, 1, 7, 0, 0, 0, time.Local)
 
 		event1 := models.Event{
-			Name:        "Event 1",
-			Format:      "NLHE",
-			Notes:       "#1",
-			SemesterID:  semester1.ID,
-			StartDate:   event1Date,
-			State:       models.EventStateStarted,
-			StructureID: structure.ID,
-			Rebuys:      0,
+			Name:             "Event 1",
+			Format:           "NLHE",
+			Notes:            "#1",
+			SemesterID:       semester1.ID,
+			StartDate:        event1Date,
+			State:            models.EventStateStarted,
+			StructureID:      structure.ID,
+			Rebuys:           0,
+			PointsMultiplier: 1.0,
 		}
 
 		res = db.Create(&event1)

--- a/internal/services/points_service.go
+++ b/internal/services/points_service.go
@@ -57,6 +57,6 @@ func getPayout(placement int) int {
 	return payouts[placement]
 }
 
-func CalculatePoints(eventSize int, placement int) int {
-	return int(math.Ceil(float64((getPayout(placement) * eventSize)) / SizeFactor))
+func CalculatePoints(eventSize int, placement int, pointsMultiplier float32) int {
+	return int(math.Ceil(float64((getPayout(placement)*eventSize))/SizeFactor) * float64(pointsMultiplier))
 }

--- a/internal/services/points_service_test.go
+++ b/internal/services/points_service_test.go
@@ -4,8 +4,9 @@ import "testing"
 
 func TestCalculatePoints(t *testing.T) {
 	type args struct {
-		eventSize int
-		placement int
+		eventSize        int
+		placement        int
+		pointsMultiplier float32
 	}
 	tests := []struct {
 		name string
@@ -15,31 +16,34 @@ func TestCalculatePoints(t *testing.T) {
 		{
 			name: "64_1st",
 			args: args{
-				eventSize: 64,
-				placement: 1,
+				eventSize:        64,
+				placement:        1,
+				pointsMultiplier: 1.0,
 			},
 			want: 41,
 		},
 		{
 			name: "64_50th",
 			args: args{
-				eventSize: 64,
-				placement: 50,
+				eventSize:        64,
+				placement:        50,
+				pointsMultiplier: 1.0,
 			},
 			want: 2,
 		},
 		{
 			name: "64_35th",
 			args: args{
-				eventSize: 64,
-				placement: 35,
+				eventSize:        64,
+				placement:        35,
+				pointsMultiplier: 2.0,
 			},
-			want: 3,
+			want: 6,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CalculatePoints(tt.args.eventSize, tt.args.placement); got != tt.want {
+			if got := CalculatePoints(tt.args.eventSize, tt.args.placement, tt.args.pointsMultiplier); got != tt.want {
 				t.Errorf("CalculatePoints() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/testhelpers/helpers.go
+++ b/internal/testhelpers/helpers.go
@@ -58,14 +58,15 @@ func CreateEvent(db *gorm.DB, name string, semesterId uuid.UUID, startDate time.
 	}
 
 	event := models.Event{
-		Name:        name,
-		Format:      "NLHE",
-		Notes:       "",
-		SemesterID:  semesterId,
-		StartDate:   startDate,
-		State:       models.EventStateStarted,
-		StructureID: structure.ID,
-		Rebuys:      0,
+		Name:             name,
+		Format:           "NLHE",
+		Notes:            "",
+		SemesterID:       semesterId,
+		StartDate:        startDate,
+		State:            models.EventStateStarted,
+		StructureID:      structure.ID,
+		Rebuys:           0,
+		PointsMultiplier: 1.0,
 	}
 
 	res = db.Create(&event)

--- a/migrations/20230905184942_add_points_multiplier_to_events.sql
+++ b/migrations/20230905184942_add_points_multiplier_to_events.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE events ADD COLUMN points_multiplier DECIMAL NOT NULL DEFAULT '1'::DECIMAL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE events DROP COLUMN points_multiplier;
+-- +goose StatementEnd


### PR DESCRIPTION
Adds a new column to `events` called `points_multiplier`. Updates the calculate points function to use this multiplier in the final step of calculating the points for an event.

Closes #205
