### PR TITLE
feat(events): add support for un-ending events

### DIFF
--- a/internal/server/events_handler.go
+++ b/internal/server/events_handler.go
@@ -58,6 +58,23 @@ func (s *apiServer) GetEvent(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, event)
 }
 
+func (s *apiServer) UndoEndEvent(ctx *gin.Context) {
+	eventId, err := strconv.ParseUint(ctx.Param("eventId"), 10, 32)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, e.InvalidRequest("Invalid event ID specified in request"))
+		return
+	}
+
+	svc := services.NewEventService(s.db)
+	err = svc.UndoEndEvent(eventId)
+	if err != nil {
+		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
+		return
+	}
+
+	ctx.String(http.StatusNoContent, "")
+}
+
 func (s *apiServer) EndEvent(ctx *gin.Context) {
 	eventId, err := strconv.ParseUint(ctx.Param("eventId"), 10, 32)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,6 +83,7 @@ func (s *apiServer) SetupRoutes() {
 		eventsRoute.POST("", s.CreateEvent)
 		eventsRoute.GET(":eventId", s.GetEvent)
 		eventsRoute.POST(":eventId/end", s.EndEvent)
+		eventsRoute.POST(":eventId/unend", s.UndoEndEvent)
 		eventsRoute.POST(":eventId/rebuy", s.NewRebuy)
 	}
 


### PR DESCRIPTION
Adds a new API route that allows users to un-end an event. This will just undo any points given so executive members can fix the standings of events.

Closes #216 