### PR TITLE
fix(events): update events with no structure to fix update error

### DIFF
--- a/migrations/20231019144616_update_all_event_structures.sql
+++ b/migrations/20231019144616_update_all_event_structures.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE events SET structure_id = 1 WHERE structure_id IS NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd


### PR DESCRIPTION
Fixes an error when ending or restarting event which was caused by events that did not have `structure_id` set. This fix creates a new migration that will update all of these events and give them the structure with `id: 1`.

Fixes #228
