### PR TITLE
fix(cors): update cors policy to allow new app endpoint

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -12,7 +12,7 @@ func CORSMiddleware(ctx *gin.Context) {
 	if strings.ToLower(os.Getenv("ENVIRONMENT")) == "production" {
 		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "https://uwpokerclub.com")
 	} else {
-		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
+		ctx.Writer.Header().Set("Access-Control-Allow-Origin", "http://localhost:5173")
 	}
 	ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 	ctx.Writer.Header().Set("Access-Control-Allow-Headers", "User-Agent, Keep-Alive, Content-Type, Content-Length, Accept-Encoding, Cache-Control")


### PR DESCRIPTION
Updates the CORS policy to allow requests from the new localhost app port when in local development.

Closes #247

