### PR TITLE
build: update go version to 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.3-stretch as build
+FROM golang:1.21.10-bullseye as build
 
 # Set Golang build environment variables
 ENV GO111MODULE=on
@@ -16,8 +16,8 @@ COPY go.sum ./
 RUN go mod download
 
 # Install development dependencies
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.6.1
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN go install github.com/pressly/goose/v3/cmd/goose@v3.15.1
 
 RUN go mod verify
 
@@ -25,7 +25,7 @@ RUN go mod verify
 COPY . .
 
 # Build executable
-RUN go build -o /app/server .
+RUN go build -buildvcs=false -o /app/server .
 
 EXPOSE 5000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       target: build
-    command: sh -c "go build -o /tmp/server . && /tmp/server start"
+    command: sh -c "go build -buildvcs=false -o /tmp/server . && /tmp/server start"
     volumes:
       - .:/app
     ports:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module api
 
-go 1.18
+go 1.21
 
 require (
 	github.com/gin-gonic/gin v1.9.1


### PR DESCRIPTION
Updates the minimum go version to 1.21, and updates the Dockerfile to pull the go 1.21.10-buster image.

Closes #221
