### PR TITLE
Modify UseAuthentication middleware to support sessions

### DIFF
--- a/internal/middleware/authentication.go
+++ b/internal/middleware/authentication.go
@@ -5,36 +5,74 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
+	"api/internal/authentication"
 	e "api/internal/errors"
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
-func UseAuthentication(ctx *gin.Context) {
-	cookie, err := ctx.Cookie("pctoken")
-	if err != nil {
-		// Cookie not present in the request. Return 401
-		ctx.AbortWithStatusJSON(http.StatusUnauthorized, e.Unauthorized("Authentication required"))
-		return
-	}
+func UseAuthentication(db *gorm.DB) func(ctx *gin.Context) {
+	return func(ctx *gin.Context) {
+		// Check if cookie is a JWT token
+		cookie, err := ctx.Cookie("pctoken")
+		if err == nil {
+			token, err := jwt.Parse(cookie, func(t *jwt.Token) (interface{}, error) {
+				if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+					return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+				}
 
-	token, err := jwt.Parse(cookie, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+				return []byte(os.Getenv("JWT_SECRET")), nil
+			})
+
+			if token.Valid {
+				ctx.Next()
+			} else if errors.Is(err, jwt.ErrTokenMalformed) {
+				ctx.AbortWithStatusJSON(http.StatusForbidden, e.Forbidden("Malformed token"))
+			} else if errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet) {
+				ctx.AbortWithStatusJSON(http.StatusUnauthorized, e.Unauthorized("Authentication required"))
+			} else {
+				ctx.AbortWithStatusJSON(http.StatusInternalServerError, e.InternalServerError(fmt.Sprintf("Unknown error occurred authenticating request: %s", err.Error())))
+			}
+			return
 		}
 
-		return []byte(os.Getenv("JWT_SECRET")), nil
-	})
+		var cookieKey string
+		if strings.ToLower(os.Getenv("ENVIRONMENT")) == "production" {
+			cookieKey = "uwpsc-session-id"
+		} else {
+			cookieKey = "uwpsc-dev-session-id"
+		}
+		cookie, err = ctx.Cookie(cookieKey)
+		if err == nil {
+			// Ensure cookie is a valid UUID
+			err = uuid.Validate(cookie)
+			if err != nil {
+				ctx.AbortWithStatusJSON(http.StatusForbidden, e.Forbidden("Invalid session ID provided"))
+				return
+			}
 
-	if token.Valid {
-		ctx.Next()
-	} else if errors.Is(err, jwt.ErrTokenMalformed) {
-		ctx.AbortWithStatusJSON(http.StatusForbidden, e.Forbidden("Malformed token"))
-	} else if errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet) {
+			sessionID, _ := uuid.Parse(cookie)
+
+			sessionManager := authentication.NewSessionManager(db)
+
+			// Authenticate this session ID
+			err = sessionManager.Authenticate(sessionID)
+			if err != nil {
+				ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
+				return
+			}
+
+			ctx.Next()
+
+			return
+		}
+
+		// Cookie not present in the request. Return 401
 		ctx.AbortWithStatusJSON(http.StatusUnauthorized, e.Unauthorized("Authentication required"))
-	} else {
-		ctx.AbortWithStatusJSON(http.StatusInternalServerError, e.InternalServerError(fmt.Sprintf("Unknown error occurred authenticating request: %s", err.Error())))
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -60,7 +60,7 @@ func (s *apiServer) SetupRoutes() {
 		sessionRoute.POST("logout", s.SessionLogoutHandler)
 	}
 
-	usersRoute := s.r.Group("/users", middleware.UseAuthentication)
+	usersRoute := s.r.Group("/users", middleware.UseAuthentication(s.db))
 	{
 		usersRoute.GET("", s.ListUsers)
 		usersRoute.POST("", s.CreateUser)
@@ -69,7 +69,7 @@ func (s *apiServer) SetupRoutes() {
 		usersRoute.DELETE(":id", s.DeleteUser)
 	}
 
-	semestersRoute := s.r.Group("/semesters", middleware.UseAuthentication)
+	semestersRoute := s.r.Group("/semesters", middleware.UseAuthentication(s.db))
 	{
 		semestersRoute.GET("", s.ListSemesters)
 		semestersRoute.POST("", s.CreateSemester)
@@ -84,7 +84,7 @@ func (s *apiServer) SetupRoutes() {
 		semestersRoute.DELETE(":semesterId/transactions/:transactionId", s.DeleteTransaction)
 	}
 
-	eventsRoute := s.r.Group("/events", middleware.UseAuthentication)
+	eventsRoute := s.r.Group("/events", middleware.UseAuthentication(s.db))
 	{
 		eventsRoute.GET("", s.ListEvents)
 		eventsRoute.POST("", s.CreateEvent)
@@ -94,7 +94,7 @@ func (s *apiServer) SetupRoutes() {
 		eventsRoute.POST(":eventId/rebuy", s.NewRebuy)
 	}
 
-	membershipRoutes := s.r.Group("/memberships", middleware.UseAuthentication)
+	membershipRoutes := s.r.Group("/memberships", middleware.UseAuthentication(s.db))
 	{
 		membershipRoutes.GET("", s.ListMemberships)
 		membershipRoutes.POST("", s.CreateMembership)
@@ -102,7 +102,7 @@ func (s *apiServer) SetupRoutes() {
 		membershipRoutes.PATCH(":id", s.UpdateMembership)
 	}
 
-	participantRoute := s.r.Group("/participants", middleware.UseAuthentication)
+	participantRoute := s.r.Group("/participants", middleware.UseAuthentication(s.db))
 	{
 		participantRoute.GET("", s.ListParticipants)
 		participantRoute.POST("", s.CreateParticipant)
@@ -111,7 +111,7 @@ func (s *apiServer) SetupRoutes() {
 		participantRoute.DELETE("", s.DeleteParticipant)
 	}
 
-	structuresRoute := s.r.Group("/structures", middleware.UseAuthentication)
+	structuresRoute := s.r.Group("/structures", middleware.UseAuthentication(s.db))
 	{
 		structuresRoute.POST("", s.CreateStructure)
 		structuresRoute.GET("", s.ListStructures)


### PR DESCRIPTION
Updates the UseAuthentication middleware to add optional support for
session based authentication. The old JWT based authentication is still
in the middleware, and will be removed once the webapp has been updated
to support session based authentication.

Closes #275
