### PR TITLE
Add pagination parameters to the list memberships route

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,7 +29,7 @@ var startCmd = &cobra.Command{
 
 		// Turn on gorm debug mode to print SQL queries to the console in local development.
 		if strings.ToLower(os.Getenv("ENVIRONMENT")) == "development" {
-			db.Debug()
+			db = db.Debug()
 		}
 
 		// Initialize cron tasks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       target: build
-    command: sh -c "go build -buildvcs=false -o /tmp/server . && /tmp/server start"
+    command: sh -c "go build -buildvcs=false -gcflags \"all=-N -l\" -o /tmp/server . && dlv exec --continue --accept-multiclient --headless --listen :4040 /tmp/server start"
     volumes:
       - .:/app
     ports:
@@ -19,6 +19,8 @@ services:
       - TEST_DATABASE_URL=postgres://docker:password@db:5432/uwpokerclub_test
     networks:
       - services
+    security_opt:
+      - "seccomp:unconfined"
 
   db:
     image: postgres:13.7-alpine

--- a/internal/models/membership.go
+++ b/internal/models/membership.go
@@ -32,3 +32,20 @@ type ListMembershipsResult struct {
 	Discounted bool      `json:"discounted"`
 	Attendance int       `json:"attendance"`
 }
+
+// ListMembershipsFilter is the set of parameters that will be used to filter the
+// list memberships query. The zero value for ListMembershipsFilter is the same as
+// not filtering the result.
+type ListMembershipsFilter struct {
+	// Limit is the the upper bound of results that will be returned by the query.
+	// If this value is nil then no limit will be put on the query.
+	Limit *int
+
+	// Offset is the number of results to offset the query result by.
+	// If this value is nil then no offset will be put on the query.
+	Offset *int
+
+	// SemesterID is the ID of the semester that you want to only list members from.
+	// If this value is nil, then the query will return results from all semesters.
+	SemesterID *uuid.UUID
+}


### PR DESCRIPTION
This PR implements `limit` and `offset` query parameters to the list memberships route. These parameters are optional, so if they are not present in the query parameters, this endpoint will perform the existing functionality of returning all members. This is to ensure backwards compatibility with the app while the pagination component is worked on. Also, I've updated the docker-compose file to support debugging with delve, making all our debugging lives easier.

Closes #309
