### PR TITLE
Add new route for retrieving session info

### DIFF
--- a/internal/authentication/session_manager.go
+++ b/internal/authentication/session_manager.go
@@ -74,3 +74,23 @@ func (svc *sessionManager) Authenticate(sessionID uuid.UUID) error {
 
 	return nil
 }
+
+func (svc *sessionManager) Get(sessionID uuid.UUID) (*models.GetSessionResponse, error) {
+	session := models.Session{ID: sessionID}
+	res := svc.db.First(&session)
+
+	err := res.Error
+	if err != nil && errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, e.Unauthorized("Authentication required")
+	}
+
+	if err != nil {
+		return nil, e.InternalServerError(err.Error())
+	}
+
+	response := models.GetSessionResponse{
+		Username: session.Username,
+	}
+
+	return &response, nil
+}

--- a/internal/authentication/session_manager_test.go
+++ b/internal/authentication/session_manager_test.go
@@ -134,4 +134,21 @@ func TestSessionManager(t *testing.T) {
 		err = sessManager.Authenticate(session.ID)
 		assert.NoError(t, err)
 	})
+
+	t.Run("Get__NoSession", func(t *testing.T) {
+		t.Cleanup(wipeDB)
+		session, err := sessManager.Get(uuid.New())
+		assert.Error(t, err)
+		assert.Nil(t, session)
+	})
+
+	t.Run("Get__ValidSession", func(t *testing.T) {
+		t.Cleanup(wipeDB)
+		session, err := CreateTestSession(db, "testuser", "password", time.Now())
+		assert.NoError(t, err)
+
+		foundSession, err := sessManager.Get(session.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, session.Username, foundSession.Username)
+	})
 }

--- a/internal/models/session.go
+++ b/internal/models/session.go
@@ -12,3 +12,7 @@ type Session struct {
 	ExpiresAt time.Time `json:"expiresAt"`
 	Username  string    `json:"username"`
 }
+
+type GetSessionResponse struct {
+	Username string `json:"username"`
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,6 +56,7 @@ func (s *apiServer) SetupRoutes() {
 	{
 		sessionRoute.POST("", s.SessionLoginHandler)
 		sessionRoute.POST("logout", s.SessionLogoutHandler)
+		sessionRoute.GET("", middleware.UseAuthentication(s.db), s.GetSessionHandler)
 	}
 
 	usersRoute := s.Router.Group("/users", middleware.UseAuthentication(s.db))


### PR DESCRIPTION
Implements and registers a new route on `GET /session` that returns the
session information for the given cookie. This session does require
prior authentication to use.

Closes #316
