### PR TITLE
fix: silence DB logs by default

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -5,7 +5,6 @@ import (
 	"api/internal/server"
 	"fmt"
 	"os"
-	"strings"
 
 	cr "api/cron"
 
@@ -25,11 +24,6 @@ var startCmd = &cobra.Command{
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to open connection to the database: %s", err.Error())
 			os.Exit(1)
-		}
-
-		// Turn on gorm debug mode to print SQL queries to the console in local development.
-		if strings.ToLower(os.Getenv("ENVIRONMENT")) == "development" {
-			db = db.Debug()
 		}
 
 		// Initialize cron tasks

--- a/internal/database/driver.go
+++ b/internal/database/driver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pressly/goose/v3"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func OpenConnection(runMigrations bool) (*gorm.DB, error) {
@@ -23,7 +24,10 @@ func OpenConnection(runMigrations bool) (*gorm.DB, error) {
 		connectionUrl = connectionUrl + "?sslmode=require&sslrootcert=certs/server-ca.pem&sslcert=client-cert/client-cert.pem&sslkey=client-key/client-key.pem"
 	}
 
-	db, err := gorm.Open(postgres.Open(connectionUrl))
+	db, err := gorm.Open(postgres.Open(connectionUrl), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to open connection to database: %s", err.Error())
 	}


### PR DESCRIPTION
This commit fixes a major security issue of SQL queries being leaked to
the console. This is because by default the GORM logger is set to log
when a query errors (i.e. a record is not found). We are turning this
down to silent and removing the check on startup to log all queries for
local development.

Fixes #323
