### PR TITLE
feat: implement filter query parameters on list users endpoint

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -37,3 +37,10 @@ type UpdateUserRequest struct {
 	Faculty   string `json:"faculty" binding:"omitempty,oneof=AHS Arts Engineering Environment Math Science"`
 	QuestID   string `json:"questId"`
 }
+
+type ListUsersFilter struct {
+	ID      *uint64
+	Name    *string
+	Email   *string
+	Faculty *string
+}

--- a/internal/server/users_handler.go
+++ b/internal/server/users_handler.go
@@ -29,11 +29,43 @@ func (s *apiServer) CreateUser(ctx *gin.Context) {
 	ctx.JSON(http.StatusCreated, user)
 }
 
+func parseListUsersQueryParams(ctx *gin.Context) *models.ListUsersFilter {
+	// Get filter parameters from query params
+	filter := models.ListUsersFilter{}
+
+	// Add user's ID to filter if it is present
+	if stringID, exists := ctx.GetQuery("id"); exists {
+		ID, err := strconv.ParseUint(stringID, 10, 64)
+		if err == nil {
+			filter.ID = &ID
+		}
+	}
+
+	// Add user's email to filter if it is present
+	if email, exists := ctx.GetQuery("email"); exists {
+		filter.Email = &email
+	}
+
+	// Add user's name to filter if it is present
+	if name, exists := ctx.GetQuery("name"); exists {
+		filter.Name = &name
+	}
+
+	// Add user's faculty to filter if it is present {
+	if faculty, exists := ctx.GetQuery("faculty"); exists {
+		filter.Faculty = &faculty
+	}
+
+	return &filter
+}
+
 func (s *apiServer) ListUsers(ctx *gin.Context) {
+	filter := parseListUsersQueryParams(ctx)
+
 	svc := services.NewUserService(s.db)
-	users, err := svc.ListUsers()
+	users, err := svc.ListUsers(filter)
 	if err != nil {
-		ctx.JSON(err.(e.APIErrorResponse).Code, err)
+		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
 		return
 	}
 

--- a/internal/services/user_service_test.go
+++ b/internal/services/user_service_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
 )
 
@@ -24,6 +25,22 @@ func TestUserService(t *testing.T) {
 		{
 			name: "ListUsers",
 			test: ListUsersTest(),
+		},
+		{
+			name: "ListUsers_FilterID",
+			test: ListUsers_FilterIDTest,
+		},
+		{
+			name: "ListUsers_FilterName",
+			test: ListUsers_FilterNameTest,
+		},
+		{
+			name: "ListUsers_FilterEmail",
+			test: ListUsers_FilterEmailTest,
+		},
+		{
+			name: "ListUsers_FilterFaculty",
+			test: ListUsers_FilterFacultyTest,
 		},
 		{
 			name: "GetUser",
@@ -141,7 +158,8 @@ func ListUsersTest() func(*testing.T) {
 
 		us := NewUserService(db)
 
-		users, err := us.ListUsers()
+		filter := models.ListUsersFilter{}
+		users, err := us.ListUsers(&filter)
 		// Should not return an error
 		if err != nil {
 			t.Errorf("Unexpected error occurred in ListUsers: %v", err)
@@ -166,6 +184,259 @@ func ListUsersTest() func(*testing.T) {
 			return
 		}
 	}
+}
+
+func ListUsers_FilterIDTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	// Create existing users
+	user1 := models.User{
+		ID:        1,
+		FirstName: "adam",
+		LastName:  "mahood",
+		Email:     "adam@gmail.com",
+		Faculty:   "Math",
+		QuestID:   "asmahood",
+	}
+	res := db.Create(&user1)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user2 := models.User{
+		ID:        2,
+		FirstName: "john",
+		LastName:  "doe",
+		Email:     "john@gmail.com",
+		Faculty:   "Science",
+		QuestID:   "jdoe",
+	}
+	res = db.Create(&user2)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user3 := models.User{
+		ID:        3,
+		FirstName: "jane",
+		LastName:  "doe",
+		Email:     "jane@gmail.com",
+		Faculty:   "Arts",
+		QuestID:   "jadoe",
+	}
+	res = db.Create(&user3)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	userService := NewUserService(db)
+
+	id := uint64(2)
+	filter := models.ListUsersFilter{
+		ID: &id,
+	}
+
+	users, err := userService.ListUsers(&filter)
+	assert.NoError(t, err, "ListUsers should not error when filtering for an ID")
+	assert.Len(t, users, 1)
+
+	user2.CreatedAt = users[0].CreatedAt
+
+	assert.Contains(t, users, user2)
+}
+
+func ListUsers_FilterNameTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	// Create existing users
+	user1 := models.User{
+		ID:        1,
+		FirstName: "adam",
+		LastName:  "mahood",
+		Email:     "adam@gmail.com",
+		Faculty:   "Math",
+		QuestID:   "asmahood",
+	}
+	res := db.Create(&user1)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user2 := models.User{
+		ID:        2,
+		FirstName: "john",
+		LastName:  "doe",
+		Email:     "john@gmail.com",
+		Faculty:   "Science",
+		QuestID:   "jdoe",
+	}
+	res = db.Create(&user2)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user3 := models.User{
+		ID:        3,
+		FirstName: "jane",
+		LastName:  "doe",
+		Email:     "jane@gmail.com",
+		Faculty:   "Arts",
+		QuestID:   "jadoe",
+	}
+	res = db.Create(&user3)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	userService := NewUserService(db)
+
+	name := "ADAM"
+	filter := models.ListUsersFilter{
+		Name: &name,
+	}
+
+	users, err := userService.ListUsers(&filter)
+	assert.NoError(t, err, "ListUsers should not error when filtering for a name")
+	assert.Len(t, users, 1)
+
+	user1.CreatedAt = users[0].CreatedAt
+
+	assert.Contains(t, users, user1)
+}
+
+func ListUsers_FilterEmailTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	// Create existing users
+	user1 := models.User{
+		ID:        1,
+		FirstName: "adam",
+		LastName:  "mahood",
+		Email:     "adam@gmail.com",
+		Faculty:   "Math",
+		QuestID:   "asmahood",
+	}
+	res := db.Create(&user1)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user2 := models.User{
+		ID:        2,
+		FirstName: "john",
+		LastName:  "doe",
+		Email:     "john@gmail.com",
+		Faculty:   "Science",
+		QuestID:   "jdoe",
+	}
+	res = db.Create(&user2)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user3 := models.User{
+		ID:        3,
+		FirstName: "jane",
+		LastName:  "doe",
+		Email:     "jane@gmail.com",
+		Faculty:   "Arts",
+		QuestID:   "jadoe",
+	}
+	res = db.Create(&user3)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	userService := NewUserService(db)
+
+	email := "adam"
+	filter := models.ListUsersFilter{
+		Email: &email,
+	}
+
+	users, err := userService.ListUsers(&filter)
+	assert.NoError(t, err, "ListUsers should not error when filtering for an email")
+	assert.Len(t, users, 1)
+
+	user1.CreatedAt = users[0].CreatedAt
+
+	assert.Contains(t, users, user1)
+}
+
+func ListUsers_FilterFacultyTest(t *testing.T) {
+	db, err := database.OpenTestConnection()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	defer database.WipeDB(db)
+
+	// Create existing users
+	user1 := models.User{
+		ID:        1,
+		FirstName: "adam",
+		LastName:  "mahood",
+		Email:     "adam@gmail.com",
+		Faculty:   "Math",
+		QuestID:   "asmahood",
+	}
+	res := db.Create(&user1)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user2 := models.User{
+		ID:        2,
+		FirstName: "john",
+		LastName:  "doe",
+		Email:     "john@gmail.com",
+		Faculty:   "Science",
+		QuestID:   "jdoe",
+	}
+	res = db.Create(&user2)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	user3 := models.User{
+		ID:        3,
+		FirstName: "jane",
+		LastName:  "doe",
+		Email:     "jane@gmail.com",
+		Faculty:   "Arts",
+		QuestID:   "jadoe",
+	}
+	res = db.Create(&user3)
+	if res.Error != nil {
+		t.Fatalf("Error when creating existing users: %v", res.Error)
+	}
+
+	userService := NewUserService(db)
+
+	faculty := models.FacultyArts
+
+	filter := models.ListUsersFilter{
+		Faculty: &faculty,
+	}
+
+	users, err := userService.ListUsers(&filter)
+	assert.NoError(t, err, "ListUsers should not error when filtering for an faculty")
+	assert.Len(t, users, 1)
+
+	user3.CreatedAt = users[0].CreatedAt
+
+	assert.Contains(t, users, user3)
 }
 
 func GetUserTest() func(*testing.T) {


### PR DESCRIPTION
This adds support for new query parameters on the list users endpoint to filter the list of users. The new supported query parameters are `id,name,email,faculty`. Both `id` and `faculty` filter on exact matches. `name` and `email` both filter on partial matches, similar to searching.

Closes #195
