### PR TITLE
feat: create route to export top 100 rankings as a CSV

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -3,7 +3,7 @@ package models
 import "time"
 
 const (
-	FacultyAHS         = "Math"
+	FacultyAHS         = "AHS"
 	FacultyArts        = "Arts"
 	FacultyEngineering = "Engineering"
 	FacultyEnvironment = "Environment"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -74,6 +74,7 @@ func (s *apiServer) SetupRoutes() {
 		semestersRoute.POST("", s.CreateSemester)
 		semestersRoute.GET(":semesterId", s.GetSemester)
 		semestersRoute.GET(":semesterId/rankings", s.GetRankings)
+		semestersRoute.GET(":semesterId/rankings/export", s.ExportRankings)
 
 		// Transaction routes
 		semestersRoute.GET(":semesterId/transactions", s.ListTransactions)


### PR DESCRIPTION
Implements a new route on the semesters API to export the top 100
rankings as CSV.

Closes #321
