### PR TITLE
feat: expose the Content-Disposition header in CORS

### DIFF
--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -17,6 +17,7 @@ func CORSMiddleware(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 	ctx.Writer.Header().Set("Access-Control-Allow-Headers", "User-Agent, Keep-Alive, Content-Type, Content-Length, Accept-Encoding, Cache-Control")
 	ctx.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, DELETE, PUT, PATCH")
+	ctx.Writer.Header().Set("Access-Control-Expose-Headers", "Content-Disposition")
 
 	if ctx.Request.Method == http.MethodOptions {
 		ctx.AbortWithStatus(204)


### PR DESCRIPTION
Adds a new CORS header to expose the Content-Disposition header to
client side javascript.

Closes #341
