### PR TITLE
feat(events): add route to event API to update events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,9 @@ exec_server:
 
 exec_db:
 	docker compose exec db psql -U docker
+
+test:
+	docker compose exec server go test -p=1 ./...
+
+logs:
+	docker compose logs -f

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -34,6 +34,14 @@ type CreateEventRequest struct {
 	PointsMultiplier float32   `json:"pointsMultiplier" binding:"required"`
 }
 
+type UpdateEventRequest struct {
+	Name             *string    `json:"name"`
+	Format           *string    `json:"format"`
+	Notes            *string    `json:"notes"`
+	StartDate        *time.Time `json:"startDate"`
+	PointsMultiplier *float32   `json:"pointsMultiplier"`
+}
+
 type ListEventsResponse struct {
 	ID         uint64    `json:"id"`
 	Name       string    `json:"name"`

--- a/internal/server/events_handler.go
+++ b/internal/server/events_handler.go
@@ -42,7 +42,7 @@ func (s *apiServer) CreateEvent(ctx *gin.Context) {
 }
 
 func (s *apiServer) GetEvent(ctx *gin.Context) {
-	eventId, err := strconv.ParseUint(ctx.Param("eventId"), 10, 32)
+	eventId, err := strconv.ParseUint(ctx.Param("eventId"), 10, 64)
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, e.InvalidRequest("Invalid event ID specified in request"))
 		return
@@ -52,6 +52,30 @@ func (s *apiServer) GetEvent(ctx *gin.Context) {
 	event, err := svc.GetEvent(eventId)
 	if err != nil {
 		ctx.JSON(err.(e.APIErrorResponse).Code, err)
+		return
+	}
+
+	ctx.JSON(http.StatusOK, event)
+}
+
+func (s *apiServer) UpdateEvent(ctx *gin.Context) {
+	eventID, err := strconv.ParseUint(ctx.Param("eventId"), 10, 64)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, e.InvalidRequest("Invalid event ID specified in request"))
+		return
+	}
+
+	var req models.UpdateEventRequest
+	err = ctx.ShouldBindJSON(&req)
+	if err != nil {
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, e.InvalidRequest(err.Error()))
+		return
+	}
+
+	svc := services.NewEventService(s.db)
+	event, err := svc.UpdateEvent(eventID, &req)
+	if err != nil {
+		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,6 +89,7 @@ func (s *apiServer) SetupRoutes() {
 		eventsRoute.GET("", s.ListEvents)
 		eventsRoute.POST("", s.CreateEvent)
 		eventsRoute.GET(":eventId", s.GetEvent)
+		eventsRoute.PATCH(":eventId", s.UpdateEvent)
 		eventsRoute.POST(":eventId/end", s.EndEvent)
 		eventsRoute.POST(":eventId/unend", s.UndoEndEvent)
 		eventsRoute.POST(":eventId/rebuy", s.NewRebuy)


### PR DESCRIPTION
Implements a new route in the Events API that allows the requester to update an events name, format, notes, start date, and points multiplier.

Closes #191
