### PR TITLE
feat(participants): setup model associations

### DIFF
--- a/internal/models/participant.go
+++ b/internal/models/participant.go
@@ -9,6 +9,7 @@ import (
 type Participant struct {
 	ID           uint64     `json:"id"`
 	MembershipID uuid.UUID  `json:"membershipId" gorm:"type:uuid"`
+	Membership   Membership `json:"membership"`
 	EventID      uint64     `json:"eventId"`
 	Placement    uint32     `json:"placement"`
 	SignedOutAt  *time.Time `json:"signedOutAt"`

--- a/internal/services/participants_service.go
+++ b/internal/services/participants_service.go
@@ -49,6 +49,7 @@ func (svc *participantsService) CreateParticipant(req *models.CreateParticipantR
 func (svc *participantsService) ListParticipants(eventId uint64) ([]models.ListParticipantsResult, error) {
 	ret := []models.ListParticipantsResult{}
 
+	// TODO: Update this query eventually to return a specific array of objects
 	subQuery := svc.db.
 		Table("participants").
 		Select("memberships.id, memberships.user_id, participants.signed_out_at, participants.placement").


### PR DESCRIPTION
Adds a new field to `Participant` called `Membership` which will be used
in the feature to enable GORM associations on queries. Right now the
queries that would use this asscoiation are custom SQL queries that
can't be changed without introducing breaking changes. We will circle
back to this in the future.

Closes #351
