### PR TITLE
feat(rankings): setup model associations

### DIFF
--- a/internal/models/membership.go
+++ b/internal/models/membership.go
@@ -10,6 +10,7 @@ type Membership struct {
 	Semester   Semester  `json:"semester"`
 	Paid       bool      `json:"paid"`
 	Discounted bool      `json:"discounted"`
+	Ranking    Ranking   `json:"ranking"`
 }
 
 type CreateMembershipRequest struct {

--- a/internal/services/semester_service.go
+++ b/internal/services/semester_service.go
@@ -171,7 +171,7 @@ func (ss *semesterService) ExportRankings(id uuid.UUID) (string, error) {
 	// Get the absolute filepath to the new file
 	fp, err := filepath.Abs(filename)
 	if err != nil {
-		return "", e.InternalServerError(fmt.Sprintf("Failed to export CSV"))
+		return "", e.InternalServerError(fmt.Sprintf("Failed to export CSV: %s", err.Error()))
 	}
 
 	return fp, nil


### PR DESCRIPTION
Adds a new `Ranking` field to the `Membership` model to set up a has one relationship between these models. This is for future proofing. Also spotted an issue in the semester service where an error wasn't being added to the error response.

- **feat(rankings): setup model associations**
- **fix: add error message to return**

Closes #352
