### PR TITLE
feat(structure): setup model associations

### DIFF
--- a/internal/models/structures.go
+++ b/internal/models/structures.go
@@ -1,8 +1,9 @@
 package models
 
 type Structure struct {
-	ID   uint64 `json:"id"`
-	Name string `json:"name"`
+	ID     uint64  `json:"id"`
+	Name   string  `json:"name"`
+	Blinds []Blind `json:"blinds"`
 }
 
 type Blind struct {
@@ -31,10 +32,4 @@ type UpdateStructureRequest struct {
 	ID     uint64
 	Name   string      `json:"name" binding:"required"`
 	Blinds []BlindJSON `json:"blinds" binding:"required,dive"`
-}
-
-type StructureWithBlindsResponse struct {
-	ID     uint64      `json:"id"`
-	Name   string      `json:"name"`
-	Blinds []BlindJSON `json:"blinds"`
 }

--- a/internal/services/structure_service.go
+++ b/internal/services/structure_service.go
@@ -18,43 +18,25 @@ func NewStructureService(db *gorm.DB) *structureService {
 	}
 }
 
-func (ss *structureService) CreateStructure(req *models.CreateStructureRequest) (*models.StructureWithBlindsResponse, error) {
-	structure := models.Structure{
-		Name: req.Name,
-	}
-
-	tx := ss.db.Begin()
-	if err := tx.Error; err != nil {
-		return nil, e.InternalServerError(err.Error())
-	}
-
-	res := tx.Create(&structure)
-	if err := res.Error; err != nil {
-		tx.Rollback()
-		return nil, e.InternalServerError(err.Error())
-	}
-
+func (ss *structureService) CreateStructure(req *models.CreateStructureRequest) (*models.Structure, error) {
 	blinds := make([]models.Blind, len(req.Blinds))
 	for i, blind := range req.Blinds {
 		blinds[i] = models.Blind{
-			Small:       blind.Small,
-			Big:         blind.Big,
-			Ante:        blind.Ante,
-			Time:        blind.Time,
-			StructureId: structure.ID,
-			Index:       i,
+			Small: blind.Small,
+			Big:   blind.Big,
+			Ante:  blind.Ante,
+			Time:  blind.Time,
+			Index: i,
 		}
 	}
 
-	res = tx.Create(&blinds)
-	if err := res.Error; err != nil {
-		tx.Rollback()
-		return nil, e.InternalServerError(err.Error())
+	structure := models.Structure{
+		Name:   req.Name,
+		Blinds: blinds,
 	}
 
-	res = tx.Commit()
+	res := ss.db.Create(&structure)
 	if err := res.Error; err != nil {
-		tx.Rollback()
 		return nil, e.InternalServerError(err.Error())
 	}
 
@@ -68,11 +50,7 @@ func (ss *structureService) CreateStructure(req *models.CreateStructureRequest) 
 		}
 	}
 
-	return &models.StructureWithBlindsResponse{
-		ID:     structure.ID,
-		Name:   structure.Name,
-		Blinds: blindsRes,
-	}, nil
+	return &structure, nil
 }
 
 func (ss *structureService) ListStructures() ([]models.Structure, error) {
@@ -86,12 +64,12 @@ func (ss *structureService) ListStructures() ([]models.Structure, error) {
 	return structures, nil
 }
 
-func (ss *structureService) GetStructure(id uint64) (*models.StructureWithBlindsResponse, error) {
+func (ss *structureService) GetStructure(id uint64) (*models.Structure, error) {
 	structure := models.Structure{
 		ID: id,
 	}
 
-	res := ss.db.First(&structure)
+	res := ss.db.Model(&structure).Preload("Blinds").First(&structure)
 	if err := res.Error; errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, e.NotFound(err.Error())
 	} else if err := res.Error; err != nil {
@@ -114,43 +92,23 @@ func (ss *structureService) GetStructure(id uint64) (*models.StructureWithBlinds
 		}
 	}
 
-	return &models.StructureWithBlindsResponse{
-		ID:     structure.ID,
-		Name:   structure.Name,
-		Blinds: blindsRes,
-	}, nil
+	return &structure, nil
 }
 
-func (ss *structureService) UpdateStructure(req *models.UpdateStructureRequest) (*models.StructureWithBlindsResponse, error) {
+func (ss *structureService) UpdateStructure(req *models.UpdateStructureRequest) (*models.Structure, error) {
 	structure := models.Structure{
 		ID: req.ID,
 	}
 
-	res := ss.db.First(&structure)
+	res := ss.db.Model(&structure).Preload("Blinds").First(&structure)
+
 	if err := res.Error; errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, e.NotFound(err.Error())
 	} else if err := res.Error; err != nil {
 		return nil, e.InternalServerError(err.Error())
 	}
 
-	tx := ss.db.Begin()
-	if err := tx.Error; err != nil {
-		return nil, e.InternalServerError(err.Error())
-	}
-
 	structure.Name = req.Name
-	res = tx.Save(&structure)
-	if err := res.Error; err != nil {
-		tx.Rollback()
-		return nil, e.InternalServerError(err.Error())
-	}
-
-	// Delete old blind levels
-	res = tx.Where("structure_id = ?", structure.ID).Delete(&models.Blind{})
-	if err := res.Error; err != nil {
-		tx.Rollback()
-		return nil, e.InternalServerError(err.Error())
-	}
 
 	// Insert new levels
 	blinds := make([]models.Blind, len(req.Blinds))
@@ -164,32 +122,12 @@ func (ss *structureService) UpdateStructure(req *models.UpdateStructureRequest) 
 			Index:       i,
 		}
 	}
-
-	res = tx.Create(&blinds)
-	if err := res.Error; err != nil {
-		tx.Rollback()
+	err := ss.db.Model(&structure).Association("Blinds").Replace(blinds)
+	if err != nil {
 		return nil, e.InternalServerError(err.Error())
 	}
 
-	res = tx.Commit()
-	if err := res.Error; err != nil {
-		tx.Rollback()
-		return nil, e.InternalServerError(err.Error())
-	}
+	ss.db.Session(&gorm.Session{FullSaveAssociations: true}).Updates(&structure)
 
-	blindsRes := make([]models.BlindJSON, len(blinds))
-	for i, blind := range blinds {
-		blindsRes[i] = models.BlindJSON{
-			Small: blind.Small,
-			Big:   blind.Big,
-			Ante:  blind.Ante,
-			Time:  blind.Time,
-		}
-	}
-
-	return &models.StructureWithBlindsResponse{
-		ID:     structure.ID,
-		Name:   structure.Name,
-		Blinds: blindsRes,
-	}, nil
+	return &structure, nil
 }

--- a/internal/services/structure_service_test.go
+++ b/internal/services/structure_service_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func assertBlindsEqual(t *testing.T, expected models.BlindJSON, actual models.Blind, msg string) {
+	assert.Equal(t, expected.Small, actual.Small, msg)
+	assert.Equal(t, expected.Big, actual.Big, msg)
+	assert.Equal(t, expected.Ante, actual.Ante, msg)
+	assert.Equal(t, expected.Time, actual.Time, msg)
+}
+
 func TestStructureService(t *testing.T) {
 	t.Setenv("ENVIRONMENT", "TEST")
 
@@ -60,9 +67,9 @@ func TestStructureService(t *testing.T) {
 		assert.NoError(t, err, "CreateStructure should not error")
 		assert.Equal(t, req.Name, structure.Name, "Structure name should be the same")
 		assert.Len(t, structure.Blinds, len(req.Blinds), "Should have the same number of blind levels")
-		assert.EqualValues(t, req.Blinds[0], structure.Blinds[0], "Blind level 1 should be the same")
-		assert.EqualValues(t, req.Blinds[1], structure.Blinds[1], "Blind level 2 should be the same")
-		assert.EqualValues(t, req.Blinds[2], structure.Blinds[2], "Blind level 3 should be the same")
+		assertBlindsEqual(t, req.Blinds[0], structure.Blinds[0], "Blind level 1 should be the same")
+		assertBlindsEqual(t, req.Blinds[1], structure.Blinds[1], "Blind level 2 should be the same")
+		assertBlindsEqual(t, req.Blinds[2], structure.Blinds[2], "Blind level 3 should be the same")
 	})
 	t.Run("ListStructures", func(t *testing.T) {
 		t.Cleanup(wipeDB)
@@ -128,16 +135,6 @@ func TestStructureService(t *testing.T) {
 				StructureId: testStructure.ID,
 			},
 		}
-		// Used for assertions
-		expectedBlindResponse := make([]models.BlindJSON, len(testBlinds))
-		for i, blind := range testBlinds {
-			expectedBlindResponse[i] = models.BlindJSON{
-				Small: blind.Small,
-				Big:   blind.Big,
-				Ante:  blind.Ante,
-				Time:  blind.Time,
-			}
-		}
 		res = db.Create(&testBlinds)
 		assert.NoError(t, res.Error)
 
@@ -146,9 +143,9 @@ func TestStructureService(t *testing.T) {
 		assert.Equal(t, testStructure.ID, structure.ID)
 		assert.Equal(t, testStructure.Name, structure.Name)
 		assert.Len(t, structure.Blinds, 3)
-		assert.EqualValues(t, expectedBlindResponse[0], structure.Blinds[0])
-		assert.EqualValues(t, expectedBlindResponse[1], structure.Blinds[1])
-		assert.EqualValues(t, expectedBlindResponse[2], structure.Blinds[2])
+		assert.EqualValues(t, testBlinds[0], structure.Blinds[0])
+		assert.EqualValues(t, testBlinds[1], structure.Blinds[1])
+		assert.EqualValues(t, testBlinds[2], structure.Blinds[2])
 	})
 	t.Run("UpdateStructure", func(t *testing.T) {
 		t.Cleanup(wipeDB)
@@ -217,8 +214,8 @@ func TestStructureService(t *testing.T) {
 		assert.Equal(t, testStructure.ID, structure.ID)
 		assert.Equal(t, req.Name, structure.Name)
 		assert.Len(t, structure.Blinds, 2)
-		assert.EqualValues(t, req.Blinds[0], structure.Blinds[0])
-		assert.EqualValues(t, req.Blinds[1], structure.Blinds[1])
+		assertBlindsEqual(t, req.Blinds[0], structure.Blinds[0], "")
+		assertBlindsEqual(t, req.Blinds[1], structure.Blinds[1], "")
 		// Check that old blinds got deleted
 		var blinds []models.Blind
 		res = db.Where("structure_id = ?", testStructure.ID).Find(&blinds)


### PR DESCRIPTION
Implements model associations on the `Structure` and `Blind` models.
Updates the routes to use these new associations in queries.

Closes #353
