### PR TITLE
feat(sessions): return the entire session in the Authenticate method

### DIFF
--- a/internal/authentication/session_manager_test.go
+++ b/internal/authentication/session_manager_test.go
@@ -103,7 +103,7 @@ func TestSessionManager(t *testing.T) {
 	t.Run("Authenticate__NoSession", func(t *testing.T) {
 		t.Cleanup(wipeDB)
 
-		err := sessManager.Authenticate(uuid.New())
+		_, err := sessManager.Authenticate(uuid.New())
 		assert.Error(t, err)
 	})
 
@@ -113,7 +113,7 @@ func TestSessionManager(t *testing.T) {
 		session, err := CreateTestSession(db, "testuser", "password", time.Now().Add(time.Hour*-9))
 		assert.NoError(t, err)
 
-		err = sessManager.Authenticate(session.ID)
+		_, err = sessManager.Authenticate(session.ID)
 		assert.Error(t, err)
 
 		// Ensure session was deleted
@@ -131,23 +131,7 @@ func TestSessionManager(t *testing.T) {
 		session, err := CreateTestSession(db, "testuser", "password", time.Now())
 		assert.NoError(t, err)
 
-		err = sessManager.Authenticate(session.ID)
-		assert.NoError(t, err)
-	})
-
-	t.Run("Get__NoSession", func(t *testing.T) {
-		t.Cleanup(wipeDB)
-		session, err := sessManager.Get(uuid.New())
-		assert.Error(t, err)
-		assert.Nil(t, session)
-	})
-
-	t.Run("Get__ValidSession", func(t *testing.T) {
-		t.Cleanup(wipeDB)
-		session, err := CreateTestSession(db, "testuser", "password", time.Now())
-		assert.NoError(t, err)
-
-		foundSession, err := sessManager.Get(session.ID)
+		foundSession, err := sessManager.Authenticate(session.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, session.Username, foundSession.Username)
 	})

--- a/internal/middleware/authentication.go
+++ b/internal/middleware/authentication.go
@@ -38,11 +38,13 @@ func UseAuthentication(db *gorm.DB) func(ctx *gin.Context) {
 		sessionManager := authentication.NewSessionManager(db)
 
 		// Authenticate this session ID
-		err = sessionManager.Authenticate(sessionID)
+		session, err := sessionManager.Authenticate(sessionID)
 		if err != nil {
 			ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
 			return
 		}
+
+		ctx.Set("username", session.Username)
 
 		ctx.Next()
 	}

--- a/internal/server/authentication_handler.go
+++ b/internal/server/authentication_handler.go
@@ -121,11 +121,13 @@ func (s *apiServer) GetSessionHandler(ctx *gin.Context) {
 	sessionUUID, _ := uuid.Parse(sessionID)
 
 	sessionManager := authentication.NewSessionManager(s.db)
-	session, err := sessionManager.Get(sessionUUID)
+	session, err := sessionManager.Authenticate(sessionUUID)
 	if err != nil {
 		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, session)
+	ctx.JSON(http.StatusOK, models.GetSessionResponse{
+		Username: session.Username,
+	})
 }


### PR DESCRIPTION
Refactors the `Authenticate` method in `SessionManager` to return the
entire session information in the case of a successful authentcation.
Additionally, sets the username of the authenticated user into the
context so it can be used in future calls.

Closes #362
