### PR TITLE
feat(authorization): implement authorization flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 )
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -52,6 +54,7 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
@@ -95,6 +98,7 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/internal/authorization/authorization_service.go
+++ b/internal/authorization/authorization_service.go
@@ -1,0 +1,58 @@
+package authorization
+
+import (
+	e "api/internal/errors"
+	"api/internal/models"
+	"errors"
+	"strings"
+
+	"gorm.io/gorm"
+)
+
+type authorizationService struct {
+	role                string
+	resourceAuthorizers ResourceAuthorizerMap
+}
+
+func NewAuthorizationService(db *gorm.DB, username string, resourceAuthorizers ResourceAuthorizerMap) (*authorizationService, error) {
+	user := models.Login{Username: username}
+
+	// Attempt to find the users role
+	res := db.Find(&user)
+	err := res.Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, e.Unauthorized("You do not have permission to perform this action.")
+		}
+		return nil, e.InternalServerError("An internal problem has occurred. Please try again later.")
+	}
+
+	svc := authorizationService{
+		role:                user.Role,
+		resourceAuthorizers: resourceAuthorizers,
+	}
+
+	return &svc, nil
+}
+
+func (svc *authorizationService) IsAuthorized(action string) bool {
+	// Validate input
+	if action == "" {
+		return false
+	}
+
+	// Split out the resource from the action string
+	parts := strings.SplitAfterN(action, ".", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	resource := strings.TrimSuffix(parts[0], ".")
+	action = parts[1]
+
+	// Check if the user is authorized to perform an action on this resource
+	authorizer, exists := svc.resourceAuthorizers[resource]
+	if !exists {
+		return false
+	}
+	return authorizer.IsAuthorized(svc.role, action)
+}

--- a/internal/authorization/authorization_service_test.go
+++ b/internal/authorization/authorization_service_test.go
@@ -1,0 +1,173 @@
+package authorization
+
+import (
+	"api/internal/database"
+	"api/internal/errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gorm.io/gorm"
+)
+
+func TestNewAuthorizationService(t *testing.T) {
+	testCases := []struct {
+		name          string
+		mockDatabase  func(mock sqlmock.Sqlmock)
+		username      string
+		expectedRole  string
+		expectError   bool
+		expectedError error
+	}{
+		{
+			name: "Can find user",
+			mockDatabase: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"username", "password", "role"}).AddRow("testuser", "password", "webmaster")
+
+				mock.ExpectQuery("^SELECT \\* FROM \"logins\" WHERE \"logins\".\"username\" = \\$1$").WillReturnRows(rows)
+			},
+			username:      "testuser",
+			expectedRole:  "webmaster",
+			expectError:   false,
+			expectedError: nil,
+		},
+		{
+			name: "Cannot find user",
+			mockDatabase: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("^SELECT \\* FROM \"logins\" WHERE \"logins\".\"username\" = \\$1$").WillReturnError(gorm.ErrRecordNotFound)
+			},
+			username:      "testuser",
+			expectedRole:  "",
+			expectError:   true,
+			expectedError: errors.Unauthorized("You do not have permission to perform this action."),
+		},
+		{
+			name: "Database error",
+			mockDatabase: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("^SELECT \\* FROM \"logins\" WHERE \"logins\".\"username\" = \\$1$").WillReturnError(gorm.ErrInvalidField)
+			},
+			username:      "testuser",
+			expectedRole:  "",
+			expectError:   true,
+			expectedError: errors.InternalServerError("An internal problem has occurred. Please try again later."),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			db, mock, err := database.NewMockDatabase()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+
+			tC.mockDatabase(mock)
+
+			authService, err := NewAuthorizationService(db, tC.username, nil)
+			if tC.expectError {
+				assert.Error(t, err)
+				if tC.expectedError != nil {
+					assert.ErrorIs(t, err, tC.expectedError)
+				}
+				assert.Nil(t, authService)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, authService)
+				assert.Equal(t, tC.expectedRole, authService.role)
+			}
+		})
+	}
+}
+
+type MockResourceAuthorizer struct {
+	mock.Mock
+}
+
+func (m *MockResourceAuthorizer) IsAuthorized(role string, action string) bool {
+	args := m.Called(role, action)
+	return args.Bool(0)
+}
+
+func TestAuthorizationService_IsAuthorized(t *testing.T) {
+	sqlMock := func(mock sqlmock.Sqlmock) {
+		rows := sqlmock.NewRows([]string{"username", "password", "role"}).AddRow("testuser", "password", "webmaster")
+		mock.ExpectQuery("^SELECT \\* FROM \"logins\" WHERE \"logins\".\"username\" = \\$1$").WillReturnRows(rows)
+	}
+
+	testCases := []struct {
+		name                   string
+		mockDatabase           func(m sqlmock.Sqlmock)
+		mockResourceAuthorizer func(m *MockResourceAuthorizer)
+		resourceAuthorizers    ResourceAuthorizerMap
+		action                 string
+		expected               bool
+	}{
+		{
+			name:                "Empty action",
+			mockDatabase:        sqlMock,
+			resourceAuthorizers: ResourceAuthorizerMap{},
+			action:              "",
+			expected:            false,
+		},
+		{
+			name:                "Only resource supplied",
+			mockDatabase:        sqlMock,
+			resourceAuthorizers: ResourceAuthorizerMap{},
+			action:              "resource",
+			expected:            false,
+		},
+		{
+			name:         "Unknown resource",
+			mockDatabase: sqlMock,
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			action:   "other.create",
+			expected: false,
+		},
+		{
+			name:         "Resource Authorized",
+			mockDatabase: sqlMock,
+			mockResourceAuthorizer: func(m *MockResourceAuthorizer) {
+				m.On("IsAuthorized", mock.Anything, mock.Anything).Return(true)
+			},
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			action:   "resource.create",
+			expected: true,
+		},
+		{
+			name:         "Resource Unauthorized",
+			mockDatabase: sqlMock,
+			mockResourceAuthorizer: func(m *MockResourceAuthorizer) {
+				m.On("IsAuthorized", mock.Anything, mock.Anything).Return(false)
+			},
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			action:   "resource.create",
+			expected: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			db, mock, err := database.NewMockDatabase()
+			if err != nil {
+				t.Fatalf("An error '%s' was not expected when opening a stub database connection", err)
+			}
+
+			tC.mockDatabase(mock)
+			if tC.mockResourceAuthorizer != nil {
+				tC.mockResourceAuthorizer(tC.resourceAuthorizers["resource"].(*MockResourceAuthorizer))
+			}
+
+			authService, err := NewAuthorizationService(db, "testuser", tC.resourceAuthorizers)
+			if err != nil {
+				t.Fatalf("NewAuthorizationService constructor should not have errored!")
+			}
+
+			result := authService.IsAuthorized(tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/event_authorizer.go
+++ b/internal/authorization/event_authorizer.go
@@ -1,0 +1,57 @@
+package authorization
+
+import "strings"
+
+type eventAuthorizer struct {
+	resourceAuthorizers ResourceAuthorizerMap
+}
+
+func NewEventAuthorizer(resourceAuthorizers ResourceAuthorizerMap) ResourceAuthorizer {
+	return &eventAuthorizer{
+		resourceAuthorizers: resourceAuthorizers,
+	}
+}
+
+func (svc *eventAuthorizer) IsAuthorized(role string, action string) bool {
+	// Validate input
+	if action == "" || role == "" {
+		return false
+	}
+
+	// Split out the resource from the action string if possible
+	var resource string
+	parts := strings.SplitAfterN(action, ".", 2)
+	if len(parts) == 1 {
+		action = parts[0]
+	} else {
+		// User wants to authorize against a sub-resource
+		resource = strings.TrimSuffix(parts[0], ".")
+		action = parts[1]
+
+		authorizer, exists := svc.resourceAuthorizers[resource]
+		if !exists {
+			return false
+		}
+		return authorizer.IsAuthorized(role, action)
+	}
+
+	// Check if user only wants to perform an action on this resource
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "edit":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "end":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "restart":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "rebuy":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/event_authorizer_test.go
+++ b/internal/authorization/event_authorizer_test.go
@@ -1,0 +1,116 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEventAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		mockResourceAuthorizer func(m *MockResourceAuthorizer)
+		resourceAuthorizers    ResourceAuthorizerMap
+		role                   string
+		action                 string
+		expected               bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "create",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Edit Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "edit",
+			expected: true,
+		},
+		{
+			name:     "End Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "end",
+			expected: true,
+		},
+		{
+			name:     "Restart Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "restart",
+			expected: true,
+		},
+		{
+			name:     "Rebuy Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "rebuy",
+			expected: true,
+		},
+		{
+			name:                "Unknown Sub-Resource",
+			resourceAuthorizers: ResourceAuthorizerMap{},
+			role:                ROLE_EXECUTIVE.ToString(),
+			action:              "resource.create",
+			expected:            false,
+		},
+		{
+			name: "Sub-Resource Unauthorized",
+			mockResourceAuthorizer: func(m *MockResourceAuthorizer) {
+				m.On("IsAuthorized", mock.Anything, mock.Anything).Return(false)
+			},
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "resource.create",
+			expected: false,
+		},
+		{
+			name: "Sub-Resource Authorized",
+			mockResourceAuthorizer: func(m *MockResourceAuthorizer) {
+				m.On("IsAuthorized", mock.Anything, mock.Anything).Return(true)
+			},
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "resource.create",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			if tC.mockResourceAuthorizer != nil {
+				tC.mockResourceAuthorizer(tC.resourceAuthorizers["resource"].(*MockResourceAuthorizer))
+			}
+
+			svc := NewEventAuthorizer(tC.resourceAuthorizers)
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/login_authorizer.go
+++ b/internal/authorization/login_authorizer.go
@@ -1,0 +1,16 @@
+package authorization
+
+type loginAuthorizer struct{}
+
+func NewLoginAuthorizer() ResourceAuthorizer {
+	return &loginAuthorizer{}
+}
+
+func (svc *loginAuthorizer) IsAuthorized(role string, action string) bool {
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/login_authorizer_test.go
+++ b/internal/authorization/login_authorizer_test.go
@@ -1,0 +1,42 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoginAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "create",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewLoginAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/membership_authorizer.go
+++ b/internal/authorization/membership_authorizer.go
@@ -1,0 +1,22 @@
+package authorization
+
+type membershipAuthorizer struct{}
+
+func NewMembershipAuthorizer() ResourceAuthorizer {
+	return &membershipAuthorizer{}
+}
+
+func (svc *membershipAuthorizer) IsAuthorized(role string, action string) bool {
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "edit":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/membership_authorizer_test.go
+++ b/internal/authorization/membership_authorizer_test.go
@@ -1,0 +1,60 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMembershipAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "create",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Edit Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "edit",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewMembershipAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/participant_authorizer.go
+++ b/internal/authorization/participant_authorizer.go
@@ -1,0 +1,26 @@
+package authorization
+
+type participantAuthorizer struct{}
+
+func NewParticipantAuthorizer() ResourceAuthorizer {
+	return &participantAuthorizer{}
+}
+
+func (svc *participantAuthorizer) IsAuthorized(role string, action string) bool {
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "signin":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "signout":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "delete":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/participant_authorizer_test.go
+++ b/internal/authorization/participant_authorizer_test.go
@@ -1,0 +1,72 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParticipantAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Sign-In Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "signin",
+			expected: true,
+		},
+		{
+			name:     "Sign-Out Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "signin",
+			expected: true,
+		},
+		{
+			name:     "Delete Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "delete",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewParticipantAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/rankings_authorizer.go
+++ b/internal/authorization/rankings_authorizer.go
@@ -1,0 +1,20 @@
+package authorization
+
+type rankingsAuthorizer struct{}
+
+func NewRankingsAuthorizer() ResourceAuthorizer {
+	return &rankingsAuthorizer{}
+}
+
+func (svc *rankingsAuthorizer) IsAuthorized(role string, action string) bool {
+	switch action {
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "export":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/rankings_authorizer_test.go
+++ b/internal/authorization/rankings_authorizer_test.go
@@ -1,0 +1,54 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRankingsAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "get",
+			expected: false,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Export Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "export",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewRankingsAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/resource_authorizer.go
+++ b/internal/authorization/resource_authorizer.go
@@ -1,0 +1,7 @@
+package authorization
+
+type ResourceAuthorizer interface {
+	IsAuthorized(role string, action string) bool
+}
+
+type ResourceAuthorizerMap map[string]ResourceAuthorizer

--- a/internal/authorization/roles.go
+++ b/internal/authorization/roles.go
@@ -1,0 +1,27 @@
+package authorization
+
+type role int
+
+const (
+	ROLE_EXECUTIVE role = iota
+)
+
+func (r role) ToString() string {
+	switch r {
+	case ROLE_EXECUTIVE:
+		return "executive"
+	}
+	return ""
+}
+
+func stringToRole(r string) role {
+	switch r {
+	case "executive":
+		return ROLE_EXECUTIVE
+	}
+	return -1
+}
+
+func HasRole(r role, userRole string) bool {
+	return r == stringToRole(userRole)
+}

--- a/internal/authorization/roles_test.go
+++ b/internal/authorization/roles_test.go
@@ -1,0 +1,73 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasRole(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     role
+		userRole string
+		expected bool
+	}{
+		{
+			name:     "Has the correct role",
+			role:     ROLE_EXECUTIVE,
+			userRole: "executive",
+			expected: true,
+		},
+		{
+			name:     "Has the incorrect role",
+			role:     ROLE_EXECUTIVE,
+			userRole: "unknown",
+			expected: false,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			assert.Equal(t, tC.expected, HasRole(tC.role, tC.userRole))
+		})
+	}
+}
+
+func TestRoleToString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     role
+		expected string
+	}{
+		{
+			name:     "Executive",
+			role:     ROLE_EXECUTIVE,
+			expected: "executive",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			role := tC.role
+			assert.Equal(t, tC.expected, role.ToString())
+		})
+	}
+}
+
+func TestStringToRole(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		role     string
+		expected role
+	}{
+		{
+			desc:     "Executive",
+			role:     "executive",
+			expected: ROLE_EXECUTIVE,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			assert.Equal(t, tC.expected, stringToRole(tC.role))
+		})
+	}
+}

--- a/internal/authorization/semester_authorizer.go
+++ b/internal/authorization/semester_authorizer.go
@@ -1,0 +1,49 @@
+package authorization
+
+import "strings"
+
+type semesterAuthorizer struct {
+	resourceAuthorizers ResourceAuthorizerMap
+}
+
+func NewSemesterAuthorizer(resourceAuthorizers ResourceAuthorizerMap) ResourceAuthorizer {
+	return &semesterAuthorizer{
+		resourceAuthorizers: resourceAuthorizers,
+	}
+}
+
+func (svc *semesterAuthorizer) IsAuthorized(role, action string) bool {
+	// Validate input
+	if action == "" {
+		return false
+	}
+
+	// Split out the sub-resource from the action string if possible
+	var resource string
+	parts := strings.SplitAfterN(action, ".", 2)
+	if len(parts) == 1 {
+		action = parts[0]
+	} else {
+		// User wants to authorized for a sub-resource
+		resource = strings.TrimSuffix(parts[0], ".")
+		action = parts[1]
+
+		authorizer, exists := svc.resourceAuthorizers[resource]
+		if !exists {
+			return false
+		}
+		return authorizer.IsAuthorized(role, action)
+	}
+
+	// Check if user only wants to perform an action on this resource
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/semester_authorizer_test.go
+++ b/internal/authorization/semester_authorizer_test.go
@@ -1,0 +1,92 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSemesterAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		mockResourceAuthorizer func(m *MockResourceAuthorizer)
+		resourceAuthorizers    ResourceAuthorizerMap
+		role                   string
+		action                 string
+		expected               bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "create",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:                "Unknown Sub-Resource",
+			resourceAuthorizers: ResourceAuthorizerMap{},
+			role:                ROLE_EXECUTIVE.ToString(),
+			action:              "resource.create",
+			expected:            false,
+		},
+		{
+			name: "Sub-Resource Unauthorized",
+			mockResourceAuthorizer: func(m *MockResourceAuthorizer) {
+				m.On("IsAuthorized", mock.Anything, mock.Anything).Return(false)
+			},
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "resource.create",
+			expected: false,
+		},
+		{
+			name: "Sub-Resource Authorized",
+			mockResourceAuthorizer: func(m *MockResourceAuthorizer) {
+				m.On("IsAuthorized", mock.Anything, mock.Anything).Return(true)
+			},
+			resourceAuthorizers: ResourceAuthorizerMap{
+				"resource": &MockResourceAuthorizer{},
+			},
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "resource.create",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			if tC.mockResourceAuthorizer != nil {
+				tC.mockResourceAuthorizer(tC.resourceAuthorizers["resource"].(*MockResourceAuthorizer))
+			}
+
+			svc := NewSemesterAuthorizer(tC.resourceAuthorizers)
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/structure_authorizer.go
+++ b/internal/authorization/structure_authorizer.go
@@ -1,0 +1,22 @@
+package authorization
+
+type structureAuthorizer struct{}
+
+func NewStructureAuthorizer() ResourceAuthorizer {
+	return &structureAuthorizer{}
+}
+
+func (svc *structureAuthorizer) IsAuthorized(role, action string) bool {
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "edit":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/structure_authorizer_test.go
+++ b/internal/authorization/structure_authorizer_test.go
@@ -1,0 +1,60 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStructureAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "create",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Edit Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "edit",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewStructureAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/transaction_authorizer.go
+++ b/internal/authorization/transaction_authorizer.go
@@ -1,0 +1,25 @@
+package authorization
+
+type transactionAuthorizer struct {
+}
+
+func NewTransactionAuthorizer() ResourceAuthorizer {
+	return &transactionAuthorizer{}
+}
+
+func (svc *transactionAuthorizer) IsAuthorized(role string, action string) bool {
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "edit":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "delete":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/transaction_authorizer_test.go
+++ b/internal/authorization/transaction_authorizer_test.go
@@ -1,0 +1,66 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransactionAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "get",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Edit Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "edit",
+			expected: true,
+		},
+		{
+			name:     "Delete Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "delete",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewTransactionAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/authorization/user_authorizer.go
+++ b/internal/authorization/user_authorizer.go
@@ -1,0 +1,24 @@
+package authorization
+
+type userAuthorizer struct{}
+
+func NewUserAuthorizer() ResourceAuthorizer {
+	return &userAuthorizer{}
+}
+
+func (svc *userAuthorizer) IsAuthorized(role string, action string) bool {
+	switch action {
+	case "create":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "get":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "list":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "edit":
+		return HasRole(ROLE_EXECUTIVE, role)
+	case "delete":
+		return HasRole(ROLE_EXECUTIVE, role)
+	}
+
+	return false
+}

--- a/internal/authorization/user_authorizer_test.go
+++ b/internal/authorization/user_authorizer_test.go
@@ -1,0 +1,66 @@
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUsernAuthorizer(t *testing.T) {
+	testCases := []struct {
+		name     string
+		role     string
+		action   string
+		expected bool
+	}{
+		{
+			name:     "No action",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "",
+			expected: false,
+		},
+		{
+			name:     "No role",
+			role:     "",
+			action:   "get",
+			expected: false,
+		},
+		{
+			name:     "Create Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "create",
+			expected: true,
+		},
+		{
+			name:     "Get Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "get",
+			expected: true,
+		},
+		{
+			name:     "List Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "list",
+			expected: true,
+		},
+		{
+			name:     "Edit Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "edit",
+			expected: true,
+		},
+		{
+			name:     "Delete Authorized",
+			role:     ROLE_EXECUTIVE.ToString(),
+			action:   "delete",
+			expected: true,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			svc := NewUserAuthorizer()
+			result := svc.IsAuthorized(tC.role, tC.action)
+			assert.Equal(t, tC.expected, result)
+		})
+	}
+}

--- a/internal/database/mock.go
+++ b/internal/database/mock.go
@@ -1,0 +1,26 @@
+package database
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func NewMockDatabase() (*gorm.DB, sqlmock.Sqlmock, error) {
+	mockDb, mock, err := sqlmock.New()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	dialector := postgres.New(postgres.Config{
+		Conn:       mockDb,
+		DriverName: "postgres",
+	})
+
+	db, err := gorm.Open(dialector, &gorm.Config{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return db, mock, nil
+}

--- a/internal/middleware/authorization.go
+++ b/internal/middleware/authorization.go
@@ -1,0 +1,46 @@
+package middleware
+
+import (
+	"api/internal/authorization"
+	"api/internal/errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func UseAuthorization(db *gorm.DB, action string) func(ctx *gin.Context) {
+	return func(ctx *gin.Context) {
+		username := ctx.GetString("username")
+		if username == "" {
+			ctx.AbortWithStatusJSON(http.StatusInternalServerError, errors.InternalServerError("An error occurred during authorization."))
+			return
+		}
+
+		authSvc, err := authorization.NewAuthorizationService(db, username, authorization.ResourceAuthorizerMap{
+			"login": authorization.NewLoginAuthorizer(),
+			"user":  authorization.NewUserAuthorizer(),
+			"semester": authorization.NewSemesterAuthorizer(authorization.ResourceAuthorizerMap{
+				"rankings":    authorization.NewRankingsAuthorizer(),
+				"transaction": authorization.NewTransactionAuthorizer(),
+			}),
+			"membership": authorization.NewMembershipAuthorizer(),
+			"structure":  authorization.NewStructureAuthorizer(),
+			"event": authorization.NewEventAuthorizer(authorization.ResourceAuthorizerMap{
+				"participant": authorization.NewParticipantAuthorizer(),
+			}),
+		})
+		if err != nil {
+			ctx.AbortWithStatusJSON(err.(errors.APIErrorResponse).Code, err)
+			return
+		}
+
+		authorized := authSvc.IsAuthorized(action)
+		if !authorized {
+			ctx.AbortWithStatusJSON(http.StatusForbidden, errors.Forbidden("You do not have permission to perform this action."))
+			return
+		}
+
+		ctx.Next()
+	}
+}

--- a/internal/models/login.go
+++ b/internal/models/login.go
@@ -3,4 +3,5 @@ package models
 type Login struct {
 	Username string `json:"username" binding:"required" gorm:"primaryKey"`
 	Password string `json:"password" binding:"required"`
+	Role     string
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -61,63 +61,63 @@ func (s *apiServer) SetupRoutes() {
 
 	usersRoute := s.Router.Group("/users", middleware.UseAuthentication(s.db))
 	{
-		usersRoute.GET("", s.ListUsers)
-		usersRoute.POST("", s.CreateUser)
-		usersRoute.GET(":id", s.GetUser)
-		usersRoute.PATCH(":id", s.UpdateUser)
-		usersRoute.DELETE(":id", s.DeleteUser)
+		usersRoute.GET("", middleware.UseAuthorization(s.db, "user.list"), s.ListUsers)
+		usersRoute.POST("", middleware.UseAuthorization(s.db, "user.create"), s.CreateUser)
+		usersRoute.GET(":id", middleware.UseAuthorization(s.db, "user.get"), s.GetUser)
+		usersRoute.PATCH(":id", middleware.UseAuthorization(s.db, "user.edit"), s.UpdateUser)
+		usersRoute.DELETE(":id", middleware.UseAuthorization(s.db, "user.delete"), s.DeleteUser)
 	}
 
 	semestersRoute := s.Router.Group("/semesters", middleware.UseAuthentication(s.db))
 	{
-		semestersRoute.GET("", s.ListSemesters)
-		semestersRoute.POST("", s.CreateSemester)
-		semestersRoute.GET(":semesterId", s.GetSemester)
-		semestersRoute.GET(":semesterId/rankings", s.GetRankings)
-		semestersRoute.GET(":semesterId/rankings/export", s.ExportRankings)
-		semestersRoute.GET(":semesterId/rankings/:membershipId", s.GetRanking)
+		semestersRoute.GET("", middleware.UseAuthorization(s.db, "semester.list"), s.ListSemesters)
+		semestersRoute.POST("", middleware.UseAuthorization(s.db, "semester.create"), s.CreateSemester)
+		semestersRoute.GET(":semesterId", middleware.UseAuthorization(s.db, "semester.get"), s.GetSemester)
+		semestersRoute.GET(":semesterId/rankings", middleware.UseAuthorization(s.db, "semester.rankings.list"), s.GetRankings)
+		semestersRoute.GET(":semesterId/rankings/export", middleware.UseAuthorization(s.db, "semester.rankings.export"), s.ExportRankings)
+		semestersRoute.GET(":semesterId/rankings/:membershipId", middleware.UseAuthorization(s.db, "semester.rankings.get"), s.GetRanking)
 
 		// Transaction routes
-		semestersRoute.GET(":semesterId/transactions", s.ListTransactions)
-		semestersRoute.POST(":semesterId/transactions", s.CreateTransaction)
-		semestersRoute.GET(":semesterId/transactions/:transactionId", s.GetTransaction)
-		semestersRoute.PATCH(":semesterId/transactions/:transactionId", s.UpdateTransaction)
-		semestersRoute.DELETE(":semesterId/transactions/:transactionId", s.DeleteTransaction)
+		semestersRoute.GET(":semesterId/transactions", middleware.UseAuthorization(s.db, "semester.transaction.list"), s.ListTransactions)
+		semestersRoute.POST(":semesterId/transactions", middleware.UseAuthorization(s.db, "semester.transaction.create"), s.CreateTransaction)
+		semestersRoute.GET(":semesterId/transactions/:transactionId", middleware.UseAuthorization(s.db, "semester.transaction.get"), s.GetTransaction)
+		semestersRoute.PATCH(":semesterId/transactions/:transactionId", middleware.UseAuthorization(s.db, "semester.transaction.edit"), s.UpdateTransaction)
+		semestersRoute.DELETE(":semesterId/transactions/:transactionId", middleware.UseAuthorization(s.db, "semester.transaction.delete"), s.DeleteTransaction)
 	}
 
 	eventsRoute := s.Router.Group("/events", middleware.UseAuthentication(s.db))
 	{
-		eventsRoute.GET("", s.ListEvents)
-		eventsRoute.POST("", s.CreateEvent)
-		eventsRoute.GET(":eventId", s.GetEvent)
-		eventsRoute.PATCH(":eventId", s.UpdateEvent)
-		eventsRoute.POST(":eventId/end", s.EndEvent)
-		eventsRoute.POST(":eventId/unend", s.UndoEndEvent)
-		eventsRoute.POST(":eventId/rebuy", s.NewRebuy)
+		eventsRoute.GET("", middleware.UseAuthorization(s.db, "event.list"), s.ListEvents)
+		eventsRoute.POST("", middleware.UseAuthorization(s.db, "event.create"), s.CreateEvent)
+		eventsRoute.GET(":eventId", middleware.UseAuthorization(s.db, "event.get"), s.GetEvent)
+		eventsRoute.PATCH(":eventId", middleware.UseAuthorization(s.db, "event.edit"), s.UpdateEvent)
+		eventsRoute.POST(":eventId/end", middleware.UseAuthorization(s.db, "event.end"), s.EndEvent)
+		eventsRoute.POST(":eventId/unend", middleware.UseAuthorization(s.db, "event.restart"), s.UndoEndEvent)
+		eventsRoute.POST(":eventId/rebuy", middleware.UseAuthorization(s.db, "event.rebuy"), s.NewRebuy)
 	}
 
 	membershipRoutes := s.Router.Group("/memberships", middleware.UseAuthentication(s.db))
 	{
-		membershipRoutes.GET("", s.ListMemberships)
-		membershipRoutes.POST("", s.CreateMembership)
-		membershipRoutes.GET(":id", s.GetMembership)
-		membershipRoutes.PATCH(":id", s.UpdateMembership)
+		membershipRoutes.GET("", middleware.UseAuthorization(s.db, "membership.list"), s.ListMemberships)
+		membershipRoutes.POST("", middleware.UseAuthorization(s.db, "membership.create"), s.CreateMembership)
+		membershipRoutes.GET(":id", middleware.UseAuthorization(s.db, "membership.get"), s.GetMembership)
+		membershipRoutes.PATCH(":id", middleware.UseAuthorization(s.db, "membership.edit"), s.UpdateMembership)
 	}
 
 	participantRoute := s.Router.Group("/participants", middleware.UseAuthentication(s.db))
 	{
-		participantRoute.GET("", s.ListParticipants)
-		participantRoute.POST("", s.CreateParticipant)
-		participantRoute.POST("sign-out", s.SignOutParticipant)
-		participantRoute.POST("sign-in", s.SignInParticipant)
-		participantRoute.DELETE("", s.DeleteParticipant)
+		participantRoute.GET("", middleware.UseAuthorization(s.db, "event.participant.list"), s.ListParticipants)
+		participantRoute.POST("", middleware.UseAuthorization(s.db, "event.participant.create"), s.CreateParticipant)
+		participantRoute.POST("sign-out", middleware.UseAuthorization(s.db, "event.participant.signout"), s.SignOutParticipant)
+		participantRoute.POST("sign-in", middleware.UseAuthorization(s.db, "event.participant.signin"), s.SignInParticipant)
+		participantRoute.DELETE("", middleware.UseAuthorization(s.db, "event.participant.delete"), s.DeleteParticipant)
 	}
 
 	structuresRoute := s.Router.Group("/structures", middleware.UseAuthentication(s.db))
 	{
-		structuresRoute.POST("", s.CreateStructure)
-		structuresRoute.GET("", s.ListStructures)
-		structuresRoute.GET(":id", s.GetStructure)
-		structuresRoute.PUT(":id", s.UpdateStructure)
+		structuresRoute.POST("", middleware.UseAuthorization(s.db, "structure.list"), s.CreateStructure)
+		structuresRoute.GET("", middleware.UseAuthorization(s.db, "structure.create"), s.ListStructures)
+		structuresRoute.GET(":id", middleware.UseAuthorization(s.db, "structure.get"), s.GetStructure)
+		structuresRoute.PUT(":id", middleware.UseAuthorization(s.db, "structure.edit"), s.UpdateStructure)
 	}
 }


### PR DESCRIPTION
Implements a new authorization flow that runs before the service layer. Adds all the necessary services/background to faciliate the addition of additional roles and resources in the future. Also in this PR is an effort to move to mocking and mocking the database. This allows us to run the tests without the docker container necessary. This will also allow us to run tests in parallel which will speed up our CI.

Closes #363
