### PR TITLE
feat(login): add authentication and authorization to create login route

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ exec_server:
 	docker compose exec server /bin/bash
 
 exec_db:
-	docker compose exec db psql -U docker
+	docker compose exec db psql -U docker -d uwpokerclub_development
 
 test:
 	docker compose exec server go test -p=1 ./...

--- a/internal/models/login.go
+++ b/internal/models/login.go
@@ -3,5 +3,5 @@ package models
 type Login struct {
 	Username string `json:"username" binding:"required" gorm:"primaryKey"`
 	Password string `json:"password" binding:"required"`
-	Role     string `gorm:"default:executive"`
+	Role     string `json:"role" binding:"oneof=bot executive tournament_director secretary treasurer vice_president president" gorm:"default:executive"`
 }

--- a/internal/server/authentication_handler.go
+++ b/internal/server/authentication_handler.go
@@ -27,14 +27,14 @@ func (s *apiServer) CreateLogin(ctx *gin.Context) {
 	var req models.Login
 	err := ctx.ShouldBindJSON(&req)
 	if err != nil {
-		ctx.JSON(http.StatusBadRequest, e.InvalidRequest(err.Error()))
+		ctx.AbortWithStatusJSON(http.StatusBadRequest, e.InvalidRequest(err.Error()))
 		return
 	}
 
 	svc := services.NewLoginService(s.db)
-	err = svc.CreateLogin(req.Username, req.Password)
+	err = svc.CreateLogin(req.Username, req.Password, req.Role)
 	if err != nil {
-		ctx.JSON(err.(e.APIErrorResponse).Code, err)
+		ctx.AbortWithStatusJSON(err.(e.APIErrorResponse).Code, err)
 		return
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -47,9 +47,9 @@ func (s *apiServer) Run(port string) {
 }
 
 func (s *apiServer) SetupRoutes() {
-	loginRoute := s.Router.Group("/login")
+	loginRoute := s.Router.Group("/login", middleware.UseAuthentication(s.db))
 	{
-		loginRoute.POST("", s.CreateLogin)
+		loginRoute.POST("", middleware.UseAuthorization(s.db, "login.create"), s.CreateLogin)
 	}
 
 	sessionRoute := s.Router.Group("/session")

--- a/internal/services/login_service.go
+++ b/internal/services/login_service.go
@@ -18,17 +18,7 @@ func NewLoginService(db *gorm.DB) *loginService {
 	}
 }
 
-func (svc *loginService) CreateLogin(username string, password string) error {
-	existingLogins := []models.Login{}
-	res := svc.db.Model(&models.Login{}).Find(&existingLogins)
-	if err := res.Error; err != nil {
-		return e.InternalServerError(err.Error())
-	}
-
-	if len(existingLogins) > 0 {
-		return e.Forbidden("You cannot perform this action")
-	}
-
+func (svc *loginService) CreateLogin(username string, password string, role string) error {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
 		return e.InternalServerError(err.Error())
@@ -37,9 +27,10 @@ func (svc *loginService) CreateLogin(username string, password string) error {
 	login := models.Login{
 		Username: username,
 		Password: string(hash),
+		Role:     role,
 	}
 
-	res = svc.db.Create(&login)
+	res := svc.db.Create(&login)
 	if err := res.Error; err != nil {
 		return e.InternalServerError(err.Error())
 	}

--- a/internal/services/login_service_test.go
+++ b/internal/services/login_service_test.go
@@ -33,7 +33,7 @@ func TestLoginService(t *testing.T) {
 	t.Run("CreateLogin", func(t *testing.T) {
 		t.Cleanup(wipeDB)
 
-		err := loginService.CreateLogin("testuser", "testpassword")
+		err := loginService.CreateLogin("testuser", "testpassword", "president")
 		if assert.NoError(t, err) {
 			var login models.Login
 			err := db.First(&login, "username = ?", "testuser").Error
@@ -42,7 +42,7 @@ func TestLoginService(t *testing.T) {
 			}
 			assert.Equal(t, "testuser", login.Username)
 			assert.NotEmpty(t, login.Password)
-			assert.Equal(t, "executive", login.Role)
+			assert.Equal(t, "president", login.Role)
 		}
 	})
 }


### PR DESCRIPTION
Adds both authentication and authorization requirements to the create
login route. Additionally, updates the route to allow a `role` field in
the request body, and for this field to be saved to the database.

Closes #368
